### PR TITLE
[Fix] 이메일 인증 로직 변경 및 다수 변경

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/apiPayload/code/GeneralErrorCode.java
@@ -10,10 +10,12 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     // 인증 에러
     DUPLICATE_LOGINID(HttpStatus.BAD_REQUEST,"AUTH_4000","중복되는 아이디가 존재합니다."),
+    NOT_AGREED_TERM(HttpStatus.BAD_REQUEST,"AUTH_4001","서비스 이용약관 동의는 필수입니다."),
     MISSING_AUTH_INFO(HttpStatus.UNAUTHORIZED, "AUTH_4010", "인증 정보가 누락되었습니다."),
     INVALID_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH_4011", "올바르지 않은 아이디, 혹은 비밀번호입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4012", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_4013", "토큰이 만료되었습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "AUTH_4014", "이메일 인증이 완료되지 않았습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4030", "접근 권한이 없습니다."),
 
     // 요청/파라미터 에러

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/AuthController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/AuthController.java
@@ -24,7 +24,15 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @Operation(summary = "로그인", description = """
+            이메일과 비밀번호로 로그인합니다.
+            - OnboardA - 회원가입 완료
+            - OnboardB - 기본 프로필 완료
+            - OnboardC - 성격 유형 완료
+            - OnboardD - AI 음성 인터뷰 완료
+            - ACTIVE - 얼굴 스캔 완료 및 온보딩 완료
+            - INACTIVE - 비활성화 및 삭제된 계정
+            """)
     @PostMapping("/login")
     public ApiResponse<LoginResDTO> login(@Valid @RequestBody LoginReqDTO request) {
         return ApiResponse.onSuccess("로그인에 성공했습니다.", authService.login(request));

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/JoinController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/JoinController.java
@@ -25,22 +25,22 @@ public class JoinController {
     private final JoinService joinService;
     private final EmailAuthService emailAuthService;
 
-    @Operation(summary = "1.기본 프로필",description = "이름,이메일,비밀번호,성별,생년월일 입력후 요청시, userId 반환 (여기서 발급된 userId를 통해 이후 회원가입 절차 진행)")
+    @Operation(summary = "1-3.기본 프로필",description = "이름,이메일,비밀번호,성별,생년월일 입력 및 이용 약관 동의 후 요청시, userId 반환 (여기서 발급된 userId를 통해 이후 온보딩 절차 진행)")
     @PostMapping("/basic-profile")
-    ApiResponse<JoinResDTO.basicProfileResDTO> basicProfile(@Valid @RequestBody JoinReqDTO.basicProfileReqDTO req) {
-        return ApiResponse.onSuccess("회원 프로필 생성 완료", joinService.basicProfile(req));
+    ApiResponse<JoinResDTO.basicProfileResDTO> basicProfile(@Valid @RequestBody JoinReqDTO.basicProfileReqDTO req, HttpSession session) {
+        return ApiResponse.onSuccess("회원 프로필 생성 완료", joinService.basicProfile(req, session));
     }
 
-    @Operation(summary = "2-1.인증번호 전송", description = "해당 이메일로 인증번호 전송")
-    @PostMapping("/send-code/{userId}")
-    ApiResponse<Void> sendCode(@PathVariable Long userId, HttpSession session) {
-        emailAuthService.sendCode(userId, session);
+    @Operation(summary = "1-1.인증번호 전송", description = "해당 이메일로 인증번호 전송")
+    @PostMapping("/send-code")
+    ApiResponse<Void> sendCode(@RequestBody JoinReqDTO.sendCodeReqDTO req, HttpSession session) {
+        emailAuthService.sendCode(req, session);
         return ApiResponse.onSuccess("인증코드 전송 완료");
     }
 
-    @Operation(summary = "2-2.이메일 인증", description = "인증번호 일치 여부 확인")
-    @PostMapping("/verify-code/{userId}")
-    ApiResponse<JoinResDTO.verifyCodeResDTO> verifyCode(@PathVariable Long userId, @RequestBody JoinReqDTO.verifyCodeReqDTO req, HttpSession session) {
-        return ApiResponse.onSuccess("인증 코드 검증 완료",emailAuthService.verifyCode(userId, req, session));
+    @Operation(summary = "1-2.이메일 인증", description = "인증번호 일치 여부 확인 (개발용 마스터 코드는 123456)")
+    @PostMapping("/verify-code")
+    ApiResponse<JoinResDTO.verifyCodeResDTO> verifyCode(@RequestBody JoinReqDTO.verifyCodeReqDTO req, HttpSession session) {
+        return ApiResponse.onSuccess("인증 코드 검증 완료",emailAuthService.verifyCode(req, session));
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
@@ -26,7 +26,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Onboarding", description = "온보딩 API")
+@Tag(name = "Onboarding", description = """
+            온보딩 API
+            
+            - UserStatus
+            - OnboardA - 회원가입 완료
+            - OnboardB - 기본 프로필 완료
+            - OnboardC - 성격 유형 완료
+            - OnboardD - AI 음성 인터뷰 완료
+            - ACTIVE - 얼굴 스캔 완료 및 온보딩 완료
+            - INACTIVE - 비활성화 및 삭제된 계정
+            """)
 @RestController
 @RequestMapping("/onboarding")
 @RequiredArgsConstructor
@@ -37,7 +47,7 @@ public class OnboardingController {
     private final RegionService regionService;
     private final VisualService visualService;
 
-    @Operation(summary = "온보딩 프로필 입력", description = "닉네임, 위치, 직업 정보를 저장합니다.")
+    @Operation(summary = "온보딩 프로필 입력", description = "닉네임, 위치, 직업 정보를 저장하고 ONBOARD_B 상태로 변경합니다.")
     @PostMapping("/profile/{userId}")
     public ApiResponse<Void> postProfile(@Valid @RequestBody OnboardingReqDTO.personaReqDTO req,
                                          @PathVariable Long userId,

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/join/JoinReqDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/join/JoinReqDTO.java
@@ -31,8 +31,16 @@ public class JoinReqDTO {
         private String password;
         private Gender gender;
         private LocalDate birthDate;
-
+        private Boolean termsAgreed;
     }
+    @Getter
+    @Setter
+    public static class sendCodeReqDTO {
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        private String email;
+    }
+
 
     @Getter
     @Setter

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/login/LoginResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/login/LoginResDTO.java
@@ -1,8 +1,11 @@
 package com.mirrorsoul.mirrorsoul_api.dto.login;
 
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
+
 public record LoginResDTO(
         String accessToken,
         String refreshToken,
-        Long userId
+        Long userId,
+        UserStatus userStatus
 ) {
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
@@ -43,8 +43,9 @@ public class AuthService {
         String accessToken = tokenProvider.createAccessToken(user);
         String refreshToken = tokenProvider.createRefreshToken(user);
         user.updateRefreshToken(refreshToken);
+        UserStatus userStatus = user.getStatus();
 
-        return new LoginResDTO(accessToken, refreshToken, user.getId());
+        return new LoginResDTO(accessToken, refreshToken, user.getId(), userStatus);
     }
 
     public RefreshTokenResDTO refresh(RefreshTokenReqDTO request) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/EmailAuthService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/EmailAuthService.java
@@ -17,19 +17,14 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class EmailAuthService {
 
-    private final UserRepository userRepository;
     private final MailService mailService;
+    private static final String DEV_MASTER_CODE = "123456";
 
     private static final long EXPIRE_SECONDS = 180L;
 
-    public void sendCode(Long userId, HttpSession session) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+    public void sendCode(JoinReqDTO.sendCodeReqDTO dto, HttpSession session) {
 
-        String email = user.getEmail();
-        if (email == null || email.isBlank()) {
-            throw new GeneralException(GeneralErrorCode.EMAIL_NOT_FOUND);
-        }
+        String email = dto.getEmail();
 
         String code = createCode();
         LocalDateTime expireTime = LocalDateTime.now().plusSeconds(EXPIRE_SECONDS);
@@ -43,14 +38,7 @@ public class EmailAuthService {
         session.setMaxInactiveInterval((int) EXPIRE_SECONDS);
     }
 
-    public JoinResDTO.verifyCodeResDTO verifyCode(Long userId, JoinReqDTO.verifyCodeReqDTO req, HttpSession session) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
-
-        String email = user.getEmail();
-        if (email == null || email.isBlank()) {
-            throw new GeneralException(GeneralErrorCode.EMAIL_NOT_FOUND);
-        }
+    public JoinResDTO.verifyCodeResDTO verifyCode(JoinReqDTO.verifyCodeReqDTO req, HttpSession session) {
 
         String savedEmail = (String) session.getAttribute(EmailAuthConst.EMAIL_AUTH_TARGET);
         String savedCode = (String) session.getAttribute(EmailAuthConst.EMAIL_AUTH_CODE);
@@ -59,10 +47,6 @@ public class EmailAuthService {
 
         if (savedEmail == null || savedCode == null || expireTime == null) {
             throw new GeneralException(GeneralErrorCode.EMAIL_CODE_NOT_REQUESTED);
-        }
-
-        if (!email.equals(savedEmail)) {
-            throw new GeneralException(GeneralErrorCode.MISSING_AUTH_INFO, "인증 요청한 이메일 정보가 일치하지 않습니다.");
         }
 
         if (Boolean.TRUE.equals(verified)) {
@@ -78,7 +62,7 @@ public class EmailAuthService {
             throw new GeneralException(GeneralErrorCode.MISSING_PARAMETER, "인증번호는 필수입니다.");
         }
 
-        if (!savedCode.equals(req.getCode())) {
+        if (!savedCode.equals(req.getCode())&& !DEV_MASTER_CODE.equals(req.getCode())) {
             throw new GeneralException(GeneralErrorCode.EMAIL_CODE_MISMATCH);
         }
 

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/JoinService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/JoinService.java
@@ -1,10 +1,14 @@
 package com.mirrorsoul.mirrorsoul_api.service;
 
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode;
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
+import com.mirrorsoul.mirrorsoul_api.common.mail.EmailAuthConst;
 import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.dto.join.JoinReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.join.JoinResDTO;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,8 +22,29 @@ public class JoinService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public JoinResDTO.basicProfileResDTO basicProfile(JoinReqDTO.basicProfileReqDTO req){
+    public JoinResDTO.basicProfileResDTO basicProfile(JoinReqDTO.basicProfileReqDTO req, HttpSession session){
 
+        String savedEmail = (String) session.getAttribute(EmailAuthConst.EMAIL_AUTH_TARGET);
+        Boolean verified = (Boolean) session.getAttribute(EmailAuthConst.EMAIL_AUTH_VERIFIED);
+
+        if (savedEmail == null) {
+            throw new GeneralException(GeneralErrorCode.EMAIL_CODE_NOT_REQUESTED);
+        }
+
+        if (!savedEmail.equals(req.getEmail())) {
+            throw new GeneralException(
+                    GeneralErrorCode.MISSING_AUTH_INFO,
+                    "인증 완료된 이메일과 가입 요청 이메일이 일치하지 않습니다."
+            );
+        }
+
+        if (!Boolean.TRUE.equals(verified)) {
+            throw new GeneralException(GeneralErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        if (!req.getTermsAgreed()) {
+            throw new GeneralException(GeneralErrorCode.NOT_AGREED_TERM);
+        }
         String encodedPassword = passwordEncoder.encode(req.getPassword());
 
         User user = User.builder()

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/OnboardingService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/OnboardingService.java
@@ -19,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 import static com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode.FORBIDDEN;
 import static com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode.REGION_NOT_FOUND;
 import static com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode.USER_NOT_FOUND;
+import static com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus.ONBOARD_A;
+import static com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus.ONBOARD_B;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +36,10 @@ public class OnboardingService {
 
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new GeneralException(USER_NOT_FOUND));
+
+        if (!ONBOARD_A.equals(user.getStatus())) {
+            throw new GeneralException(FORBIDDEN, "ONBOARD_A 상태의 사용자만 페르소나를 저장할 수 있습니다.");
+        }
 
         user.setName(req.getNickname());
 
@@ -57,6 +63,7 @@ public class OnboardingService {
 
         user.setJob(job);
         user.setJobDescription(req.getJobDescription());
+        user.setStatus(ONBOARD_B);
         userRepository.save(user);
     }
 
@@ -76,7 +83,7 @@ public class OnboardingService {
         User user = userRepository.findById(userId).orElseThrow(
                 () -> new GeneralException(USER_NOT_FOUND));
 
-        if (!UserStatus.ONBOARD_B.equals(user.getStatus())) {
+        if (!ONBOARD_B.equals(user.getStatus())) {
             throw new GeneralException(FORBIDDEN, "ONBOARD_B 상태의 사용자만 성격 유형을 저장할 수 있습니다.");
         }
 


### PR DESCRIPTION
## #️⃣ 작업 내용
1. 이메일 인증 Request로 이메일주소 받도록 수정 (POST /join/send-code)
2.인증번호 일치 여부는 세션 내 이메일 주소를 받아서 인증 진행하도록 수정 (POST /join/verify-code)
3.개발용 마스터 인증코드 : 123456 (스웨거에도 적어놨슴다)
4.이용 약관 여부 Boolean 필드 추가 (POST /join/basic-profile)
5.로그인 시 온보딩 진행상태(userStatus) 확인할수 있도록 변경 (POST /auth/login)
6.UserStatus 정리 문서화
<img width="916" height="428" alt="스크린샷 2026-05-09 오후 5 41 04" src="https://github.com/user-attachments/assets/e5a3d423-5fc3-4134-95c1-2e7932b3082f" />
