### PR TITLE
[Feat] CustomUserDetails 도입

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
@@ -39,9 +39,7 @@ public class SecurityConfig {
                                 "/auth/login",
                                 "/auth/refresh",
                                 "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/onboarding/regions/**",
-                                "/onboarding/interview/questions"
+                                "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.mirrorsoul.mirrorsoul_api.common.config;
 
+import com.mirrorsoul.mirrorsoul_api.common.jwt.JwtAuthenticationFilter;
 import com.mirrorsoul.mirrorsoul_api.common.jwt.JwtProperties;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,14 +14,17 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableConfigurationProperties(JwtProperties.class)
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -27,7 +33,19 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/join/**",
+                                "/auth/login",
+                                "/auth/refresh",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/onboarding/regions/**",
+                                "/onboarding/interview/questions"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .cors(Customizer.withDefaults())
                 .build();
     }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.mirrorsoul.mirrorsoul_api.common.jwt;
+
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetails;
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetailsService;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                tokenProvider.validateAccessToken(token);
+
+                Long userId = tokenProvider.getUserIdFromToken(token);
+                CustomUserDetails userDetails = customUserDetailsService.loadUserById(userId);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (JwtException | IllegalArgumentException e) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return null;
+        }
+
+        String token = authorization.substring("Bearer ".length()).trim();
+        return token.isBlank() ? null : token;
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/security/CustomUserDetails.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/security/CustomUserDetails.java
@@ -1,0 +1,40 @@
+package com.mirrorsoul.mirrorsoul_api.common.security;
+
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final UUID uuid;
+    private final String email;
+    private final String password;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.uuid = user.getUuid();
+        this.email = user.getEmail();
+        this.password = user.getPasswordHash();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/security/CustomUserDetailsService.java
@@ -1,0 +1,22 @@
+package com.mirrorsoul.mirrorsoul_api.common.security;
+
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode;
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetails loadUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/swagger/SwaggerConfig.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/swagger/SwaggerConfig.java
@@ -33,7 +33,6 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(info)
                 .addServersItem(new Server().url("/"))
-                .addSecurityItem(securityRequirement)
                 .components(components);
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
@@ -1,6 +1,7 @@
 package com.mirrorsoul.mirrorsoul_api.controller;
 
 import com.mirrorsoul.mirrorsoul_api.common.apiPayload.ApiResponse;
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetails;
 import com.mirrorsoul.mirrorsoul_api.dto.call.CallReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.call.CallResDTO;
 import com.mirrorsoul.mirrorsoul_api.service.CallService;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Call", description = "유저-클론 통화 API")
@@ -23,11 +25,12 @@ public class CallController {
     @PostMapping("/clones/{clone-user-uuid}")
     public ApiResponse<CallResDTO.StartCallDTO> startCloneCall(
             @PathVariable("clone-user-uuid") UUID cloneUserUuid,
-            @Valid @RequestBody CallReqDTO.StartCallDTO request
+            @Valid @RequestBody CallReqDTO.StartCallDTO request,
+            @AuthenticationPrincipal CustomUserDetails currentUser
     ) {
         return ApiResponse.onSuccess(
                 "클론 통화 세션 생성에 성공했습니다.",
-                callService.startCloneCall(cloneUserUuid, request)
+                callService.startCloneCall(cloneUserUuid, request, currentUser.getUuid())
         );
     }
 

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
@@ -6,6 +6,7 @@ import com.mirrorsoul.mirrorsoul_api.dto.call.CallReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.call.CallResDTO;
 import com.mirrorsoul.mirrorsoul_api.service.CallService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -14,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Call", description = "유저-클론 통화 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/calls")
 @RequiredArgsConstructor

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/EvolveController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/EvolveController.java
@@ -6,6 +6,7 @@ import com.mirrorsoul.mirrorsoul_api.dto.evolve.EvolveResDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerReqDTO;
 import com.mirrorsoul.mirrorsoul_api.service.EvolveService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Evolve", description = "Evolve 관련 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/evolve")
 @RequiredArgsConstructor

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/EvolveController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/EvolveController.java
@@ -1,17 +1,16 @@
 package com.mirrorsoul.mirrorsoul_api.controller;
 
 import com.mirrorsoul.mirrorsoul_api.common.apiPayload.ApiResponse;
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetails;
 import com.mirrorsoul.mirrorsoul_api.dto.evolve.EvolveResDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerReqDTO;
 import com.mirrorsoul.mirrorsoul_api.service.EvolveService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
 
 @Tag(name = "Evolve", description = "Evolve 관련 API")
 @RestController
@@ -22,25 +21,27 @@ public class EvolveController {
     private final EvolveService evolveService;
 
     @Operation(summary = "트윈 완성도 조회 api", description = "트윈 완성도를 %(퍼센트) 단위로 조회합니다.")
-    @GetMapping("/{clone-user-uuid}")
-    public ApiResponse<EvolveResDTO.twinSyncDTO> getTwinSync(@Parameter(description = "사용자 UUID") @PathVariable("clone-user-uuid") UUID userUuid){
-        return ApiResponse.onSuccess("트윈 완성도 조회에 성공했습니다.",evolveService.twinSync(userUuid));
+    @GetMapping
+    public ApiResponse<EvolveResDTO.twinSyncDTO> getTwinSync(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess("트윈 완성도 조회에 성공했습니다.", evolveService.twinSync(currentUser.getUuid()));
     }
 
     @Operation(summary = "목소리 업데이트 - 녹음 api", description = "녹음을 위한 문장을 생성합니다.")
-    @GetMapping("/{clone-user-uuid}/voice")
-    public ApiResponse<EvolveResDTO.speechLineDTO> startRecording(@Parameter(description = "사용자 UUID") @PathVariable("clone-user-uuid") UUID userUuid){
-        return ApiResponse.onSuccess("녹음을 위한 문장 생성에 성공했습니다.",evolveService.speechLine(userUuid));
+    @GetMapping("/voice")
+    public ApiResponse<EvolveResDTO.speechLineDTO> startRecording(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess("녹음을 위한 문장 생성에 성공했습니다.", evolveService.speechLine(currentUser.getUuid()));
     }
 
     @Operation(summary = "목소리 업데이트 - 녹음완료 api", description = "녹음 완료한 음성파일을 저장합니다.")
-    @PostMapping("/{clone-user-uuid}/voice")
-    public ApiResponse<Void> completeRecording(@Parameter(description = "사용자 UUID") @PathVariable("clone-user-uuid") UUID userUuid,
-                                               @Valid @RequestBody InterviewAnswerReqDTO request){
-        return ApiResponse.onSuccess("ai서버와 연결 완료 후 개발 완료 예정",null);
+    @PostMapping("/voice")
+    public ApiResponse<Void> completeRecording(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody InterviewAnswerReqDTO request
+    ) {
+        return ApiResponse.onSuccess("ai서버와 연결 완료 후 개발 완료 예정", null);
     }
-
-
-
-
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/FileController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/FileController.java
@@ -5,6 +5,7 @@ import com.mirrorsoul.mirrorsoul_api.dto.file.PresignedUrlReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.file.PresignedUrlResDTO;
 import com.mirrorsoul.mirrorsoul_api.service.FileService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "File", description = "파일 업로드 지원 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
 @RequestMapping("/files")
 @RequiredArgsConstructor

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
@@ -14,6 +14,7 @@ import com.mirrorsoul.mirrorsoul_api.service.OnboardingService;
 import com.mirrorsoul.mirrorsoul_api.service.RegionService;
 import com.mirrorsoul.mirrorsoul_api.service.VisualService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -48,6 +49,7 @@ public class OnboardingController {
     private final RegionService regionService;
     private final VisualService visualService;
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "온보딩 프로필 입력", description = "닉네임, 위치, 직업 정보를 저장하고 ONBOARD_B 상태로 변경합니다.")
     @PostMapping("/profile")
     public ApiResponse<Void> postProfile(@Valid @RequestBody OnboardingReqDTO.personaReqDTO req,
@@ -66,6 +68,7 @@ public class OnboardingController {
         return ApiResponse.onSuccess("사용 불가능한 중복 닉네임입니다.");
     }
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "온보딩 성격 유형 저장", description = "MBTI, 각 지표 점수, 자기소개를 저장하고 ONBOARD_C 상태로 변경합니다.")
     @PutMapping("/personality")
     public ApiResponse<Void> putPersonality(@Valid @RequestBody OnboardingReqDTO.personalityReqDTO req,
@@ -96,12 +99,14 @@ public class OnboardingController {
         );
     }
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "온보딩 인터뷰 질문 전체 조회", description = "온보딩 단계에서 사용하는 인터뷰 질문 전체를 조회합니다.")
     @GetMapping("/interview/questions")
     public ApiResponse<InterviewQuestionResDTO.questionListResDTO> getInterviewQuestions() {
         return ApiResponse.onSuccess("인터뷰 질문 조회에 성공했습니다.", interviewService.getQuestions());
     }
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "온보딩 인터뷰 응답 저장", description = "온보딩 단계에서 로그인 사용자 기준으로 인터뷰 응답을 저장하거나 수정합니다.")
     @PostMapping("/interview/answers")
     public ApiResponse<InterviewAnswerResDTO> saveInterviewAnswer(@AuthenticationPrincipal CustomUserDetails currentUser,
@@ -112,6 +117,7 @@ public class OnboardingController {
         );
     }
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "온보딩 얼굴 이미지 파일 저장", description = "S3 업로드가 완료된 얼굴 이미지 파일의 objectKey와 fileUrl을 로그인 사용자 기준으로 저장합니다.")
     @PostMapping("/visual")
     public ApiResponse<VisualResDTO> saveVisualFile(@AuthenticationPrincipal CustomUserDetails currentUser,

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
@@ -1,6 +1,7 @@
 package com.mirrorsoul.mirrorsoul_api.controller;
 
 import com.mirrorsoul.mirrorsoul_api.common.apiPayload.ApiResponse;
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetails;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.Job;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerResDTO;
@@ -13,14 +14,12 @@ import com.mirrorsoul.mirrorsoul_api.service.OnboardingService;
 import com.mirrorsoul.mirrorsoul_api.service.RegionService;
 import com.mirrorsoul.mirrorsoul_api.service.VisualService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,11 +49,11 @@ public class OnboardingController {
     private final VisualService visualService;
 
     @Operation(summary = "온보딩 프로필 입력", description = "닉네임, 위치, 직업 정보를 저장하고 ONBOARD_B 상태로 변경합니다.")
-    @PostMapping("/profile/{user-uuid}")
+    @PostMapping("/profile")
     public ApiResponse<Void> postProfile(@Valid @RequestBody OnboardingReqDTO.personaReqDTO req,
-                                         @Parameter(description = "사용자 UUID") @PathVariable("user-uuid") UUID userUuid,
-                                         @RequestParam Job job) {
-        onboardingService.postProfile(req, userUuid, job);
+                                         @RequestParam Job job,
+                                         @AuthenticationPrincipal CustomUserDetails currentUser) {
+        onboardingService.postProfile(req, currentUser.getUuid(), job);
         return ApiResponse.onSuccess("프로필 정보 저장 완료");
     }
 
@@ -68,10 +67,10 @@ public class OnboardingController {
     }
 
     @Operation(summary = "온보딩 성격 유형 저장", description = "MBTI, 각 지표 점수, 자기소개를 저장하고 ONBOARD_C 상태로 변경합니다.")
-    @PutMapping("/personality/{user-uuid}")
+    @PutMapping("/personality")
     public ApiResponse<Void> putPersonality(@Valid @RequestBody OnboardingReqDTO.personalityReqDTO req,
-                                            @Parameter(description = "사용자 UUID") @PathVariable("user-uuid") UUID userUuid) {
-        onboardingService.putPersonality(req, userUuid);
+                                            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        onboardingService.putPersonality(req, currentUser.getUuid());
         return ApiResponse.onSuccess("성격 유형 저장 완료");
     }
 
@@ -103,23 +102,23 @@ public class OnboardingController {
         return ApiResponse.onSuccess("인터뷰 질문 조회에 성공했습니다.", interviewService.getQuestions());
     }
 
-    @Operation(summary = "온보딩 인터뷰 응답 저장", description = "온보딩 단계에서 userUuid 기준으로 인터뷰 응답을 저장하거나 수정합니다.")
-    @PostMapping("/interview/answers/{user-uuid}")
-    public ApiResponse<InterviewAnswerResDTO> saveInterviewAnswer(@Parameter(description = "사용자 UUID") @PathVariable("user-uuid") UUID userUuid,
+    @Operation(summary = "온보딩 인터뷰 응답 저장", description = "온보딩 단계에서 로그인 사용자 기준으로 인터뷰 응답을 저장하거나 수정합니다.")
+    @PostMapping("/interview/answers")
+    public ApiResponse<InterviewAnswerResDTO> saveInterviewAnswer(@AuthenticationPrincipal CustomUserDetails currentUser,
                                                                   @Valid @RequestBody InterviewAnswerReqDTO request) {
         return ApiResponse.onSuccess(
                 "인터뷰 응답 저장에 성공했습니다.",
-                interviewService.saveInterviewAnswer(userUuid, request)
+                interviewService.saveInterviewAnswer(currentUser.getUuid(), request)
         );
     }
 
-    @Operation(summary = "온보딩 얼굴 이미지 파일 저장", description = "S3 업로드가 완료된 얼굴 이미지 파일의 objectKey와 fileUrl을 userUuid 기준으로 저장합니다.")
-    @PostMapping("/visual/{user-uuid}")
-    public ApiResponse<VisualResDTO> saveVisualFile(@Parameter(description = "사용자 UUID") @PathVariable("user-uuid") UUID userUuid,
+    @Operation(summary = "온보딩 얼굴 이미지 파일 저장", description = "S3 업로드가 완료된 얼굴 이미지 파일의 objectKey와 fileUrl을 로그인 사용자 기준으로 저장합니다.")
+    @PostMapping("/visual")
+    public ApiResponse<VisualResDTO> saveVisualFile(@AuthenticationPrincipal CustomUserDetails currentUser,
                                                     @RequestBody VisualReqDTO request) {
         return ApiResponse.onSuccess(
                 "얼굴 이미지 파일 저장에 성공했습니다.",
-                visualService.saveVisualFile(userUuid, request)
+                visualService.saveVisualFile(currentUser.getUuid(), request)
         );
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/call/CallReqDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/call/CallReqDTO.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 public class CallReqDTO {
 
     public record StartCallDTO(
-            @NotNull UUID callerUserUuid,
             CallMediaType mediaType
     ) {
     }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/CallService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/CallService.java
@@ -29,8 +29,8 @@ public class CallService {
     private final CloneRepository cloneRepository;
 
     @Transactional
-    public CallResDTO.StartCallDTO startCloneCall(UUID cloneUserUuid, CallReqDTO.StartCallDTO request) {
-        User caller = userRepository.findByUuid(request.callerUserUuid())
+    public CallResDTO.StartCallDTO startCloneCall(UUID cloneUserUuid, CallReqDTO.StartCallDTO request, UUID userUUID) {
+        User caller = userRepository.findByUuid(userUUID)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
         Clone clone = cloneRepository.findByUserUuid(cloneUserUuid)


### PR DESCRIPTION
## #️⃣ 작업 내용

### User-uuid를 파라미터로 받지 않고 로그인 유저 정보 추출하도록 변경
기능 | 기존 API | 변경 후 API
-- | -- | --
온보딩 프로필 입력 | POST /onboarding/profile/{user-uuid} | POST /onboarding/profile
온보딩 성격 유형 저장 | PUT /onboarding/personality/{user-uuid} | PUT /onboarding/personality
온보딩 인터뷰 응답 저장 | POST /onboarding/interview/answers/{user-uuid} | POST /onboarding/interview/answers
온보딩 얼굴 이미지 파일 저장 | POST /onboarding/visual/{user-uuid} | POST /onboarding/visual
클론에게 음성/영상 통화 걸기 | POST /calls/clones/{clone-user-uuid} + body에 callerUserUuid 포함 | POST /calls/clones/{clone-user-uuid} + body에서 callerUserUuid 제거


위 API들은 더 이상 URL에 userUuid를 포함하지 않고, Authorization: Bearer {accessToken} 헤더 기준으로 로그인 사용자를 식별함
(Evolve API도 수정했지만 아직 연동하지 않은 API이므로 설명 생략)


### 스웨거 상에서 로그인이 필요한 기능들은 자물쇠 아이콘 추가
<img width="2904" height="914" alt="스크린샷 2026-05-25 오후 12 56 31" src="https://github.com/user-attachments/assets/ef419a6f-533a-48fb-b4da-2cc70ee80690" />

아래 사진처럼 api 오른쪽에 자물쇠 아이콘 확인 가능


