### PR TITLE
fix token-expired error in logout api

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                                 "/join/**",
                                 "/auth/login",
                                 "/auth/refresh",
+                                "/auth/logout",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/ws/signaling"

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtTokenProvider.java
@@ -40,6 +40,13 @@ public class JwtTokenProvider implements TokenProvider {
     }
 
     @Override
+    public Long getUserIdFromAccessTokenAllowExpired(String token) {
+        Claims claims = parseClaimsAllowExpired(token);
+        assertTokenType(claims, "access");
+        return Long.valueOf(claims.getSubject());
+    }
+
+    @Override
     public void validateAccessToken(String token) {
         validateTokenType(token, "access");
     }
@@ -52,14 +59,18 @@ public class JwtTokenProvider implements TokenProvider {
     private void validateTokenType(String token, String expectedTokenType) {
         try {
             Claims claims = parseClaims(token);
-            String tokenType = claims.get("tokenType", String.class);
-            if (!expectedTokenType.equals(tokenType)) {
-                throw new JwtException("Invalid token type");
-            }
+            assertTokenType(claims, expectedTokenType);
         } catch (ExpiredJwtException e) {
             throw e;
         } catch (JwtException | IllegalArgumentException e) {
             throw new JwtException("Invalid token", e);
+        }
+    }
+
+    private void assertTokenType(Claims claims, String expectedTokenType) {
+        String tokenType = claims.get("tokenType", String.class);
+        if (!expectedTokenType.equals(tokenType)) {
+            throw new JwtException("Invalid token type");
         }
     }
 
@@ -82,5 +93,13 @@ public class JwtTokenProvider implements TokenProvider {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    private Claims parseClaimsAllowExpired(String token) {
+        try {
+            return parseClaims(token);
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/TokenProvider.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/jwt/TokenProvider.java
@@ -10,6 +10,8 @@ public interface TokenProvider {
 
     Long getUserIdFromToken(String token);
 
+    Long getUserIdFromAccessTokenAllowExpired(String token);
+
     void validateAccessToken(String token);
 
     void validateRefreshToken(String token);

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
@@ -76,15 +76,13 @@ public class AuthService {
     public void logout(String authorizationHeader) {
         String accessToken = extractBearerToken(authorizationHeader);
 
+        Long userId;
         try {
-            tokenProvider.validateAccessToken(accessToken);
-        } catch (ExpiredJwtException e) {
-            throw new GeneralException(GeneralErrorCode.TOKEN_EXPIRED, "Access token has expired.");
+            userId = tokenProvider.getUserIdFromAccessTokenAllowExpired(accessToken);
         } catch (JwtException | IllegalArgumentException e) {
             throw new GeneralException(GeneralErrorCode.INVALID_TOKEN, "Invalid access token.");
         }
 
-        Long userId = tokenProvider.getUserIdFromToken(accessToken);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.INVALID_TOKEN, "User for token not found."));
 

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/common/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,28 @@
+package com.mirrorsoul.mirrorsoul_api.common.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "01234567890123456789012345678901";
+
+    @Test
+    void getUserIdFromAccessTokenAllowExpiredReturnsSubjectFromExpiredAccessToken() {
+        JwtProperties jwtProperties = new JwtProperties(SECRET, -1L, 1209600L);
+        JwtTokenProvider tokenProvider = new JwtTokenProvider(jwtProperties);
+        User user = User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .passwordHash("password")
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        String expiredAccessToken = tokenProvider.createAccessToken(user);
+
+        assertThat(tokenProvider.getUserIdFromAccessTokenAllowExpired(expiredAccessToken)).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## #️⃣ 작업 내용

> 로그아웃 시 access token이 만료돼 있으면 생기는 에러 해결
로그아웃에서는 이제 만료된 access token도 TOKEN_EXPIRED로 거부하지 않고, 서명과 tokenType=access만 확인한 뒤 userId를 꺼내 refresh token을 삭제

## #️⃣ 테스트 결과

> 

## #️⃣ 리뷰 요구사항 (선택)

