### PR TITLE
feat: add profile settings and call time management

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/apiPayload/code/GeneralErrorCode.java
@@ -46,6 +46,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
     // 유저 관련 에러
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4040", "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER_4090", "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USER_4091", "이미 사용 중인 닉네임입니다."),
 
     // 지역 관련 에러
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION_4040", "존재하지 않는 지역입니다."),
@@ -64,6 +65,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
     // 통화 관련 에러
     CALL_NOT_FOUND(HttpStatus.NOT_FOUND, "CALL_4040", "통화 정보를 찾을 수 없습니다."),
     CALL_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "CALL_4000", "이미 종료된 통화입니다."),
+    INSUFFICIENT_TALK_TIME(HttpStatus.BAD_REQUEST, "CALL_4001", "남은 대화 시간이 부족합니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/CallController.java
@@ -47,11 +47,12 @@ public class CallController {
     @PostMapping("/{call-id}/end")
     public ApiResponse<CallResDTO.EndCallDTO> endCall(
             @PathVariable("call-id") Long callId,
-            @RequestBody(required = false) CallReqDTO.EndCallDTO request
+            @RequestBody(required = false) CallReqDTO.EndCallDTO request,
+            @AuthenticationPrincipal CustomUserDetails currentUser
     ) {
         return ApiResponse.onSuccess(
                 "통화 종료에 성공했습니다.",
-                callService.endCall(callId, request)
+                callService.endCall(callId, request, currentUser.getUuid())
         );
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/ProfileController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/ProfileController.java
@@ -1,0 +1,135 @@
+package com.mirrorsoul.mirrorsoul_api.controller;
+
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.ApiResponse;
+import com.mirrorsoul.mirrorsoul_api.common.security.CustomUserDetails;
+import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileReqDTO;
+import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileResDTO;
+import com.mirrorsoul.mirrorsoul_api.service.ProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Profile", description = "Profile 관련 API")
+@SecurityRequirement(name = "bearerAuth")
+@RestController
+@RequestMapping("/my-page")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @Operation(summary = "마이페이지 진입 api", description = "마이페이지에 필요한 이름, 이메일 정보를 조회합니다.")
+    @GetMapping
+    public ApiResponse<ProfileResDTO.myProfileDTO> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess(
+                "마이페이지 조회에 성공했습니다.",
+                profileService.getMyProfile(currentUser.getUuid())
+        );
+    }
+
+    @Operation(summary = "나의 시간 조회 api", description = "나의 현재 남은 시간을 조회합니다.")
+    @GetMapping("/buy-time")
+    public ApiResponse<ProfileResDTO.timeStatusDTO> myTime(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess(
+                "잔여 대화 시간 조회에 성공했습니다.",
+                profileService.getMyTime(currentUser.getUuid())
+        );
+    }
+
+    @Operation(summary = "대화 시간 채우기 api", description = "시간은 초단위로 계산하므로, 30분 추가->1800, 2시간 추가->7200, 10시간 추가->36000 으로 입력합니다.")
+    @PostMapping("/buy-time")
+    public ApiResponse<ProfileResDTO.timeStatusDTO> buyTime(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody ProfileReqDTO.buyTimeReqDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                "대화 시간 충전에 성공했습니다.",
+                profileService.buyTime(currentUser.getUuid(), request)
+        );
+    }
+
+    @Operation(summary = "음성 및 오디오 설정 조회 api", description = "상대방 목소리 크기와 말하기 속도를 조회합니다. 말하기 속도의 ENUM값은 SLOW, NORMAL, FAST")
+    @GetMapping("/audio-settings")
+    public ApiResponse<ProfileResDTO.audioSettingsDTO> getAudioSettings(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess(
+                "음성 및 오디오 설정 조회에 성공했습니다.",
+                profileService.getAudioSettings(currentUser.getUuid())
+        );
+    }
+
+    @Operation(summary = "음성 및 오디오 설정 수정 api", description = "상대방 목소리 크기와 말하기 속도를 수정합니다. 말하기 속도의 ENUM값은 SLOW, NORMAL, FAST")
+    @PatchMapping("/audio-settings")
+    public ApiResponse<ProfileResDTO.audioSettingsDTO> updateAudioSettings(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody ProfileReqDTO.audioSettingsReqDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                "음성 및 오디오 설정 수정에 성공했습니다.",
+                profileService.updateAudioSettings(currentUser.getUuid(), request)
+        );
+    }
+
+    @Operation(summary = "알림 설정 여부 조회 api")
+    @GetMapping("/alarm")
+    public ApiResponse<ProfileResDTO.alarmSettingDTO> getAlarmSetting (
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess(
+                "알림 설정 조회에 성공했습니다.",
+                profileService.getAlarmSetting(currentUser.getUuid())
+        );
+    }
+
+    @Operation(summary = "알림 설정 수정 api")
+    @PatchMapping("/alarm")
+    public ApiResponse<ProfileResDTO.alarmSettingDTO> modifyAlarmSetting (
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody ProfileReqDTO.alarmSettingReqDTO request
+    ) {
+        return ApiResponse.onSuccess(
+                "알림 설정 수정에 성공했습니다.",
+                profileService.modifyAlarmSetting(currentUser.getUuid(), request)
+        );
+    }
+
+    // TODO 나중에 소셜로그인 확장시 소셜계정 연동 현황 조회 추가
+    @Operation(summary = "계정관리 api", description = "자신의 닉네임, 소셜계정 연동 여부를 조회합니다. (현재는 닉네임만)")
+    @GetMapping("/account")
+    public ApiResponse<ProfileResDTO.accountInfoDTO> accountInfo (
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return ApiResponse.onSuccess(
+                "계정 정보 조회에 성공했습니다.",
+                profileService.getAccountInfo(currentUser.getUuid())
+        );
+    }
+
+    @Operation(summary = "닉네임 변경 api", description = "자신의 닉네임을 수정합니다.")
+    @PostMapping("/account")
+    public ApiResponse<Void> modifyNickname (
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody ProfileReqDTO.modifyNicknameReqDTO request
+    ) {
+        profileService.modifyNickname(currentUser.getUuid(), request);
+        return ApiResponse.onSuccess("닉네임 수정에 성공했습니다.");
+    }
+
+    @Operation(summary = "회원 탈퇴 api", description = "계정을 비활성화(Soft Delete)합니다. 30일 뒤에 계정은 영구 삭제됩니다.")
+    @DeleteMapping
+    public ApiResponse<Void> inActiveAccount (
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        profileService.inactiveAccount(currentUser.getUuid());
+        return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/User.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/User.java
@@ -62,6 +62,27 @@ public class User extends BaseTimeEntity {
     @Column(name = "self_introduction", length = 500)
     private String selfIntroduction;
 
+    @Builder.Default
+    @Column(name = "remaining_talk_time", nullable = false)
+    private Integer remainingTalkTime = 1800;
+
+    @Builder.Default
+    @Column(name = "opponent_voice_volume", nullable = false)
+    private Integer opponentVoiceVolume = 50;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "opponent_speech_speed", nullable = false, length = 20)
+    private SpeechSpeed opponentSpeechSpeed = SpeechSpeed.NORMAL;
+
+    @Builder.Default
+    @Column(name = "missed_call_notification_enabled", nullable = false)
+    private Boolean missedCallNotificationEnabled = true;
+
+    @Builder.Default
+    @Column(name = "low_time_notification_enabled", nullable = false)
+    private Boolean lowTimeNotificationEnabled = true;
+
     @Column(name = "birth_date")
     private LocalDate birthDate;
 
@@ -86,6 +107,32 @@ public class User extends BaseTimeEntity {
 
     public void clearRefreshToken() {
         this.refreshToken = null;
+    }
+
+    public void addTalkTime(int seconds) {
+        this.remainingTalkTime = getSafeRemainingTalkTime() + seconds;
+    }
+
+    public void useTalkTime(int seconds) {
+        this.remainingTalkTime = Math.max(0, getSafeRemainingTalkTime() - seconds);
+    }
+
+    public void updateAudioSettings(int opponentVoiceVolume, SpeechSpeed opponentSpeechSpeed) {
+        this.opponentVoiceVolume = opponentVoiceVolume;
+        this.opponentSpeechSpeed = opponentSpeechSpeed;
+    }
+
+    public void updateAlarmSettings(boolean missedCallNotificationEnabled, boolean lowTimeNotificationEnabled) {
+        this.missedCallNotificationEnabled = missedCallNotificationEnabled;
+        this.lowTimeNotificationEnabled = lowTimeNotificationEnabled;
+    }
+
+    public boolean hasTalkTime() {
+        return getSafeRemainingTalkTime() > 0;
+    }
+
+    private int getSafeRemainingTalkTime() {
+        return remainingTalkTime == null ? 0 : remainingTalkTime;
     }
 
     @PrePersist

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/enums/SpeechSpeed.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/enums/SpeechSpeed.java
@@ -1,0 +1,7 @@
+package com.mirrorsoul.mirrorsoul_api.domain.enums;
+
+public enum SpeechSpeed {
+    SLOW,
+    NORMAL,
+    FAST
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/call/CallResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/call/CallResDTO.java
@@ -22,7 +22,8 @@ public class CallResDTO {
     public record EndCallDTO(
             Long callId,
             VideoCallStatus status,
-            Integer durationSec
+            Integer durationSec,
+            Integer remainingTalkTime
     ) {
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/profile/ProfileReqDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/profile/ProfileReqDTO.java
@@ -1,0 +1,54 @@
+package com.mirrorsoul.mirrorsoul_api.dto.profile;
+
+import com.mirrorsoul.mirrorsoul_api.domain.enums.SpeechSpeed;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class ProfileReqDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class buyTimeReqDTO {
+        @NotNull
+        @Min(1)
+        Integer buyTime;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class audioSettingsReqDTO {
+        @NotNull
+        @Min(0)
+        @Max(100)
+        Integer opponentVoiceVolume;
+
+        @NotNull
+        SpeechSpeed opponentSpeechSpeed;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class modifyNicknameReqDTO {
+        @NotBlank(message = "닉네임은 필수입니다.")
+        String nickname;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class alarmSettingReqDTO {
+        @NotNull
+        Boolean missedCallNotificationEnabled;
+
+        @NotNull
+        Boolean lowTimeNotificationEnabled;
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/profile/ProfileResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/profile/ProfileResDTO.java
@@ -1,0 +1,56 @@
+package com.mirrorsoul.mirrorsoul_api.dto.profile;
+
+import com.mirrorsoul.mirrorsoul_api.domain.enums.SpeechSpeed;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProfileResDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class myProfileDTO {
+        String name;
+        String email;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class timeStatusDTO {
+        Integer remainingTalkTime;
+        Integer hours;
+        Integer minutes;
+        Integer seconds;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class audioSettingsDTO {
+        Integer opponentVoiceVolume;
+        SpeechSpeed opponentSpeechSpeed;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class accountInfoDTO {
+        String name;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class alarmSettingDTO {
+        Boolean missedCallNotificationEnabled;
+        Boolean lowTimeNotificationEnabled;
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/CallService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/CallService.java
@@ -33,6 +33,10 @@ public class CallService {
         User caller = userRepository.findByUuid(userUUID)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
 
+        if (!caller.hasTalkTime()) {
+            throw new GeneralException(GeneralErrorCode.INSUFFICIENT_TALK_TIME);
+        }
+
         Clone clone = cloneRepository.findByUserUuid(cloneUserUuid)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.CLONE_NOT_FOUND));
 
@@ -77,8 +81,12 @@ public class CallService {
     }
 
     @Transactional
-    public CallResDTO.EndCallDTO endCall(Long callId, CallReqDTO.EndCallDTO request) {
+    public CallResDTO.EndCallDTO endCall(Long callId, CallReqDTO.EndCallDTO request, UUID userUuid) {
         VideoCall call = getCall(callId);
+
+        if (!call.getUser().getUuid().equals(userUuid)) {
+            throw new GeneralException(GeneralErrorCode.FORBIDDEN);
+        }
 
         if (call.getStatus() == VideoCallStatus.COMPLETED ||
                 call.getStatus() == VideoCallStatus.CANCELLED ||
@@ -91,11 +99,13 @@ public class CallService {
         }
 
         call.complete();
+        call.getUser().useTalkTime(call.getDurationSec());
 
         return CallResDTO.EndCallDTO.builder()
                 .callId(call.getId())
                 .status(call.getStatus())
                 .durationSec(call.getDurationSec())
+                .remainingTalkTime(call.getUser().getRemainingTalkTime())
                 .build();
     }
 

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/ProfileService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/ProfileService.java
@@ -1,0 +1,132 @@
+package com.mirrorsoul.mirrorsoul_api.service;
+
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode;
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
+import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileReqDTO;
+import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileResDTO;
+import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+
+    public ProfileResDTO.myProfileDTO getMyProfile(UUID userUuid) {
+        User user = getUser(userUuid);
+
+        return ProfileResDTO.myProfileDTO.builder()
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
+    }
+
+    public ProfileResDTO.timeStatusDTO getMyTime(UUID userUuid) {
+        User user = getUser(userUuid);
+        return toTimeStatus(user.getRemainingTalkTime());
+    }
+
+    @Transactional
+    public ProfileResDTO.timeStatusDTO buyTime(UUID userUuid, ProfileReqDTO.buyTimeReqDTO request) {
+        User user = getUser(userUuid);
+        user.addTalkTime(request.getBuyTime());
+
+        return toTimeStatus(user.getRemainingTalkTime());
+    }
+
+    public ProfileResDTO.audioSettingsDTO getAudioSettings(UUID userUuid) {
+        User user = getUser(userUuid);
+
+        return ProfileResDTO.audioSettingsDTO.builder()
+                .opponentVoiceVolume(user.getOpponentVoiceVolume())
+                .opponentSpeechSpeed(user.getOpponentSpeechSpeed())
+                .build();
+    }
+
+    @Transactional
+    public ProfileResDTO.audioSettingsDTO updateAudioSettings(UUID userUuid, ProfileReqDTO.audioSettingsReqDTO request) {
+        User user = getUser(userUuid);
+        user.updateAudioSettings(request.getOpponentVoiceVolume(), request.getOpponentSpeechSpeed());
+
+        return ProfileResDTO.audioSettingsDTO.builder()
+                .opponentVoiceVolume(user.getOpponentVoiceVolume())
+                .opponentSpeechSpeed(user.getOpponentSpeechSpeed())
+                .build();
+    }
+
+    public ProfileResDTO.alarmSettingDTO getAlarmSetting(UUID userUuid) {
+        User user = getUser(userUuid);
+
+        return ProfileResDTO.alarmSettingDTO.builder()
+                .missedCallNotificationEnabled(user.getMissedCallNotificationEnabled())
+                .lowTimeNotificationEnabled(user.getLowTimeNotificationEnabled())
+                .build();
+    }
+
+    @Transactional
+    public ProfileResDTO.alarmSettingDTO modifyAlarmSetting(UUID userUuid, ProfileReqDTO.alarmSettingReqDTO request) {
+        User user = getUser(userUuid);
+        user.updateAlarmSettings(
+                request.getMissedCallNotificationEnabled(),
+                request.getLowTimeNotificationEnabled()
+        );
+
+        return ProfileResDTO.alarmSettingDTO.builder()
+                .missedCallNotificationEnabled(user.getMissedCallNotificationEnabled())
+                .lowTimeNotificationEnabled(user.getLowTimeNotificationEnabled())
+                .build();
+    }
+
+    public ProfileResDTO.accountInfoDTO getAccountInfo(UUID userUuid) {
+        User user = getUser(userUuid);
+
+        return ProfileResDTO.accountInfoDTO.builder()
+                .name(user.getName())
+                .build();
+    }
+
+    @Transactional
+    public void modifyNickname(UUID userUuid, ProfileReqDTO.modifyNicknameReqDTO request) {
+        User user = getUser(userUuid);
+        String nickname = request.getNickname().trim();
+
+        if (!nickname.equals(user.getName()) && userRepository.existsByName(nickname)) {
+            throw new GeneralException(GeneralErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.setName(nickname);
+    }
+
+    @Transactional
+    public void inactiveAccount(UUID userUuid) {
+        User user = getUser(userUuid);
+        user.setStatus(UserStatus.INACTIVE);
+        user.clearRefreshToken();
+    }
+
+    private User getUser(UUID userUuid) {
+        return userRepository.findByUuid(userUuid)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.USER_NOT_FOUND));
+    }
+
+    private ProfileResDTO.timeStatusDTO toTimeStatus(Integer remainingTalkTime) {
+        int safeRemainingTime = Math.max(remainingTalkTime == null ? 0 : remainingTalkTime, 0);
+        int hours = safeRemainingTime / 3600;
+        int minutes = (safeRemainingTime % 3600) / 60;
+        int seconds = safeRemainingTime % 60;
+
+        return ProfileResDTO.timeStatusDTO.builder()
+                .remainingTalkTime(safeRemainingTime)
+                .hours(hours)
+                .minutes(minutes)
+                .seconds(seconds)
+                .build();
+    }
+}

--- a/src/main/resources/db/migration/V11__add_user_profile_settings.sql
+++ b/src/main/resources/db/migration/V11__add_user_profile_settings.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN remaining_talk_time INT NOT NULL DEFAULT 1800,
+    ADD COLUMN opponent_voice_volume INT NOT NULL DEFAULT 50,
+    ADD COLUMN opponent_speech_speed VARCHAR(20) NOT NULL DEFAULT 'NORMAL',
+    ADD COLUMN missed_call_notification_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN low_time_notification_enabled BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
- GET /my-page : 이름, 이메일 조회
- GET /my-page/buy-time : 잔여 통화 시간 조회
- POST /my-page/buy-time : 통화 시간 충전
- GET /my-page/audio-settings : 음성/오디오 설정 조회
- PATCH /my-page/audio-settings : 음성/오디오 설정 수정
- GET /my-page/alarm : 알림 설정 조회
- PATCH /my-page/alarm : 알림 설정 수정
- GET /my-page/account : 계정 정보 조회
- POST /my-page/account : 닉네임 변경
- DELETE /my-page : 회원 탈퇴 soft delete 처리

1. 시간 충전 개념이 추가됨에 따라 통화시 시간 차감되는 기능 추가하였습니다.

2. 신규회원에게 기본으로 주어지는 통화시간은 일단 1800초 (30분)으로 설정하였습니다.
<img width="578" height="274" alt="스크린샷 2026-07-06 오후 1 13 55" src="https://github.com/user-attachments/assets/b7a31c3f-707f-480f-8d36-21383d6cc26a" />

3. 목소리 크기, 말하기 속도 초기값은 회원가입시 디폴트 값으로 설정됨 (50, NORMAL)
<img width="640" height="346" alt="스크린샷 2026-07-06 오후 1 15 58" src="https://github.com/user-attachments/assets/4bea115f-d74c-465e-a5c3-4177464210eb" />

4.알림 설정의 경우는 우선 부재중 알림, 시간 소진 알림 설정 필드만 만들었습니다. 혜택 및 이벤트 알림에 대해서는 회의때 얘기 나눈후에 추가 구현하도록 하겠습니다.
<img width="1338" height="610" alt="스크린샷 2026-07-06 오후 1 18 20" src="https://github.com/user-attachments/assets/fdf63e22-257a-4fd6-b0fd-8c63545a248d" />

5. 회원 탈퇴 soft delete 기한은 30일로 하였습니다.