### PR TITLE
[Feat] ai_voice_profile 엔티티 추가

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/AiVoiceProfile.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/AiVoiceProfile.java
@@ -1,0 +1,69 @@
+package com.mirrorsoul.mirrorsoul_api.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "ai_voice_profiles")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiVoiceProfile extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "clone_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ai_voice_profiles_clone"))
+    private Clone clone;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "voice_training_job_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_ai_voice_profiles_voice_training_job"))
+    private VoiceTrainingJob voiceTrainingJob;
+
+    @Column(name = "elevenlabs_voice_id")
+    private String elevenlabsVoiceId;
+
+    @Column(nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    private AiVoiceProfile(
+            Clone clone,
+            VoiceTrainingJob voiceTrainingJob,
+            String elevenlabsVoiceId,
+            String status,
+            boolean active
+    ) {
+        this.clone = clone;
+        this.voiceTrainingJob = voiceTrainingJob;
+        this.elevenlabsVoiceId = elevenlabsVoiceId;
+        this.status = status;
+        this.active = active;
+    }
+
+    public static AiVoiceProfile create(
+            Clone clone,
+            VoiceTrainingJob voiceTrainingJob,
+            String elevenlabsVoiceId,
+            String status,
+            boolean active
+    ) {
+        return new AiVoiceProfile(clone, voiceTrainingJob, elevenlabsVoiceId, status, active);
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/AiVoiceProfileRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/AiVoiceProfileRepository.java
@@ -1,0 +1,7 @@
+package com.mirrorsoul.mirrorsoul_api.repository;
+
+import com.mirrorsoul.mirrorsoul_api.domain.AiVoiceProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AiVoiceProfileRepository extends JpaRepository<AiVoiceProfile, Long> {
+}

--- a/src/main/resources/db/migration/V14__add_ai_voice_profiles.sql
+++ b/src/main/resources/db/migration/V14__add_ai_voice_profiles.sql
@@ -1,0 +1,21 @@
+CREATE TABLE ai_voice_profiles (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    clone_id BIGINT NOT NULL,
+    voice_training_job_id BIGINT NOT NULL,
+    elevenlabs_voice_id VARCHAR(255) NULL,
+    status VARCHAR(20) NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT pk_ai_voice_profiles PRIMARY KEY (id),
+    CONSTRAINT fk_ai_voice_profiles_clone
+        FOREIGN KEY (clone_id) REFERENCES clones(id)
+            ON DELETE CASCADE,
+    CONSTRAINT fk_ai_voice_profiles_voice_training_job
+        FOREIGN KEY (voice_training_job_id) REFERENCES voice_training_jobs(id)
+            ON DELETE CASCADE
+);
+
+CREATE INDEX idx_ai_voice_profiles_clone_active
+    ON ai_voice_profiles (clone_id, is_active);


### PR DESCRIPTION
## #️⃣ 작업 내용

<p>ElevenLabs에서 생성된 AI 음성 정보를 관리하기 위해 <code>AiVoiceProfile</code> 엔티티와 <code>ai_voice_profiles</code> 테이블을 추가했습니다.</p><div><div>

필드 | 타입 | 설명
-- | -- | --
id | BIGINT | PK, Auto Increment
clone_id | BIGINT | clones.id FK
voice_training_job_id | BIGINT | 음성 생성에 사용된 voice_training_jobs.id FK
elevenlabs_voice_id | VARCHAR(255) | ElevenLabs에서 발급한 음성 ID, 생성 전까지 nullable
status | VARCHAR(20) | 음성 프로필 생성 상태
is_active | BOOLEAN | 현재 활성화된 음성 여부, 기본값 false
created_at | DATETIME | 생성 시각
updated_at | DATETIME | 수정 시각

</body></html>

</div></div><h3>연관관계</h3><ul><li><code>AiVoiceProfile</code> N:1 <code>Clone</code></li><li><code>AiVoiceProfile</code> N:1 <code>VoiceTrainingJob</code></li><li>Clone 또는 음성 학습 작업 삭제 시 관련 음성 프로필도 삭제되도록 <code>ON DELETE CASCADE</code>를 적용했습니다.</li></ul><h3>기타</h3><ul><li>활성 프로필 조회 성능을 위해 <code>(clone_id, is_active)</code> 복합 인덱스를 추가했습니다.</li><li>상태 값이 아직 확정되지 않아 <code>status</code>는 enum 대신 문자열로 정의했습니다.</li><li>Flyway <code>V14__add_ai_voice_profiles.sql</code>을 통해 테이블을 생성합니다.</li></ul>
