### PR TITLE
[Fix] 이메일 중복 처리 개선

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/JoinService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/JoinService.java
@@ -13,6 +13,7 @@ import com.mirrorsoul.mirrorsoul_api.repository.CloneRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +52,10 @@ public class JoinService {
             throw new GeneralException(GeneralErrorCode.NOT_AGREED_TERM);
         }
 
+        if (userRepository.existsByEmail(req.getEmail())) {
+            throw new GeneralException(GeneralErrorCode.DUPLICATE_EMAIL);
+        }
+
         String encodedPassword = passwordEncoder.encode(req.getPassword());
 
         User user = User.builder()
@@ -61,7 +66,13 @@ public class JoinService {
                 .status(UserStatus.ONBOARD_A)
                 .build();
 
-        userRepository.save(user);
+        try {
+            // Flush here so a concurrent signup violating uk_users_email is
+            // translated before this method returns.
+            userRepository.saveAndFlush(user);
+        } catch (DataIntegrityViolationException exception) {
+            throw new GeneralException(GeneralErrorCode.DUPLICATE_EMAIL);
+        }
 
         Clone clone = Clone.builder()
                 .user(user)

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/service/JoinServiceTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/service/JoinServiceTest.java
@@ -1,0 +1,91 @@
+package com.mirrorsoul.mirrorsoul_api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode;
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
+import com.mirrorsoul.mirrorsoul_api.common.jwt.TokenProvider;
+import com.mirrorsoul.mirrorsoul_api.common.mail.EmailAuthConst;
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.dto.join.JoinReqDTO;
+import com.mirrorsoul.mirrorsoul_api.repository.CloneRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class JoinServiceTest {
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private CloneRepository cloneRepository;
+    private JoinService joinService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        passwordEncoder = mock(PasswordEncoder.class);
+        cloneRepository = mock(CloneRepository.class);
+        joinService = new JoinService(
+                userRepository,
+                passwordEncoder,
+                cloneRepository,
+                mock(TokenProvider.class)
+        );
+    }
+
+    @Test
+    void basicProfileRejectsEmailAlreadyInUse() {
+        JoinReqDTO.basicProfileReqDTO request = request("duplicate@example.com");
+        HttpSession session = verifiedSession(request.getEmail());
+        when(userRepository.existsByEmail(request.getEmail())).thenReturn(true);
+
+        assertDuplicateEmail(() -> joinService.basicProfile(request, session));
+
+        verify(userRepository, never()).saveAndFlush(any(User.class));
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    void basicProfileTranslatesConcurrentUniqueConstraintViolation() {
+        JoinReqDTO.basicProfileReqDTO request = request("race@example.com");
+        HttpSession session = verifiedSession(request.getEmail());
+        when(userRepository.existsByEmail(request.getEmail())).thenReturn(false);
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("encoded");
+        when(userRepository.saveAndFlush(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("uk_users_email"));
+
+        assertDuplicateEmail(() -> joinService.basicProfile(request, session));
+
+        verify(cloneRepository, never()).save(any());
+    }
+
+    private void assertDuplicateEmail(Runnable invocation) {
+        assertThatThrownBy(invocation::run)
+                .isInstanceOfSatisfying(GeneralException.class,
+                        exception -> assertThat(exception.getCode())
+                                .isEqualTo(GeneralErrorCode.DUPLICATE_EMAIL));
+    }
+
+    private JoinReqDTO.basicProfileReqDTO request(String email) {
+        JoinReqDTO.basicProfileReqDTO request = new JoinReqDTO.basicProfileReqDTO();
+        request.setEmail(email);
+        request.setPassword("password1");
+        request.setTermsAgreed(true);
+        return request;
+    }
+
+    private HttpSession verifiedSession(String email) {
+        HttpSession session = mock(HttpSession.class);
+        when(session.getAttribute(EmailAuthConst.EMAIL_AUTH_TARGET)).thenReturn(email);
+        when(session.getAttribute(EmailAuthConst.EMAIL_AUTH_VERIFIED)).thenReturn(true);
+        return session;
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 회원가입 최종 제출 단계의 이메일 중복 처리 로직을 보완했습니다.
- JoinService.basicProfile()에서 사용자 저장 전 existsByEmail() 중복 검사 추가
- 동시 가입 요청으로 발생할 수 있는 레이스 컨디션에 대응
- save()를 saveAndFlush()로 변경하여 DB unique 제약 위반을 서비스 내부에서 즉시 감지
- DataIntegrityViolationException 발생 시 DUPLICATE_EMAIL로 변환
- 이메일 중복 시 500 INTERNAL_SERVER_ERROR 대신 409 USER_4090 응답
