### PR TITLE
[Fix] 추천 리스트 조회 파라미터 수정

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/HomeController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/HomeController.java
@@ -10,11 +10,14 @@ import com.mirrorsoul.mirrorsoul_api.service.RecommendService;
 import com.mirrorsoul.mirrorsoul_api.service.RecommendationDetailService;
 import com.mirrorsoul.mirrorsoul_api.service.SwipeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -79,8 +82,15 @@ public class HomeController {
     @GetMapping("/recommend")
     public ApiResponse<RecommendResDTO.RecommendationSliceDTO> recommend(
             @AuthenticationPrincipal CustomUserDetails currentUser,
-            @PageableDefault(size = 20) Pageable pageable
+
+            @Parameter(description = "페이지 번호 (디폴트 값은 0)")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "한 페이지에서 조회할 추천 사용자 수 (디폴트 값은 20)")
+            @RequestParam(defaultValue = "20") int size
     ) {
+        Pageable pageable = PageRequest.of(page, size);
+
         return ApiResponse.onSuccess(
                 "추천 유저 리스트 조회에 성공했습니다.",
                 recommendService.getRecommendations(currentUser.getUuid(), pageable)


### PR DESCRIPTION
- GET /home/recommend의 페이징 파라미터를 Pageable 객체에서 page, size 쿼리 파라미터로 변경
- Swagger에서 각 파라미터의 기본값과 설명이 명확하게 표시되도록 개선
- 전달받은 page, size로 PageRequest를 생성하여 기존 추천 조회 로직에 전달
<img width="1254" height="954" alt="스크린샷 2026-08-13 오후 4 21 27" src="https://github.com/user-attachments/assets/04e20c64-1e78-4cce-b7aa-70860af9a252" />
