### PR TITLE
[Fix] 선호지역 설정 쿼리 수정

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/UserPreferredSigunguRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/UserPreferredSigunguRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserPreferredSigunguRepository
         extends JpaRepository<UserPreferredSigungu, Long> {
@@ -17,5 +19,9 @@ public interface UserPreferredSigunguRepository
     Optional<UserPreferredSigungu> findFirstByUserIdOrderByCreatedAtDescIdDesc(Long userId);
 
     @Modifying(flushAutomatically = true)
-    void deleteAllByUserId(Long userId);
+    @Query("""
+            delete from UserPreferredSigungu preference
+            where preference.user.id = :userId
+            """)
+    int deleteAllByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
### 변경 사항
- deleteAllByUserId()를 Spring Data 파생 삭제 방식에서 명시적인 JPQL 벌크 DELETE로 변경
- 기존 선호지역 DELETE가 신규 선호지역 INSERT보다 먼저 DB에 반영되도록 수정
- 동일한 선호지역을 재설정할 때 uk_user_sigungu unique 제약 위반으로 500 오류가 발생하는 문제 해결