### PR TITLE
[FIX] 8월 17일 회의록 내용 반영

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/MirrorsoulApiApplication.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/MirrorsoulApiApplication.java
@@ -2,8 +2,10 @@ package com.mirrorsoul.mirrorsoul_api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MirrorsoulApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/common/webRTC/SignalingHandler.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/common/webRTC/SignalingHandler.java
@@ -1,7 +1,10 @@
 package com.mirrorsoul.mirrorsoul_api.common.webRTC;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -11,6 +14,7 @@ import tools.jackson.databind.ObjectMapper;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SignalingHandler extends TextWebSocketHandler {
 
     private static final String AI_SERVER_SIGNAL_ID = "ai-server";
@@ -20,7 +24,7 @@ public class SignalingHandler extends TextWebSocketHandler {
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
-        System.out.println("WebSocket connected: " + session.getId());
+        log.info("Signaling WebSocket connected. sessionId={}", session.getId());
     }
 
     @Override
@@ -31,7 +35,7 @@ public class SignalingHandler extends TextWebSocketHandler {
         switch (signalingMessage.getType()) {
             case "JOIN" -> handleJoin(session, signalingMessage);
             case "CALL_INVITE", "CALL_ACCEPT", "CALL_REJECT", "CALL_END",
-                 "OFFER", "ANSWER", "ICE" -> relayMessage(signalingMessage);
+                 "OFFER", "ANSWER", "ICE" -> relayMessage(session, signalingMessage);
             case "LEAVE" -> handleLeave(signalingMessage);
             default -> throw new IllegalArgumentException("Unknown signaling type: " + signalingMessage.getType());
         }
@@ -50,19 +54,76 @@ public class SignalingHandler extends TextWebSocketHandler {
 
         session.sendMessage(new TextMessage(objectMapper.writeValueAsString(joinedMessage)));
 
-        System.out.println("Joined signaling: " + message.getFrom());
+        log.info(
+                "Signaling participant joined. signalId={}, sessionId={}",
+                message.getFrom(),
+                session.getId()
+        );
     }
 
-    private void relayMessage(SignalingMessage message) throws IOException {
+    private void relayMessage(WebSocketSession senderSession, SignalingMessage message) throws IOException {
         WebSocketSession receiverSession = getReceiverSession(message.getTo());
 
         if (receiverSession == null || !receiverSession.isOpen()) {
-            System.out.println("Receiver not connected: " + message.getTo());
+            log.warn(
+                    "Signaling receiver unavailable. type={}, roomId={}, from={}, to={}",
+                    message.getType(),
+                    message.getRoomId(),
+                    message.getFrom(),
+                    message.getTo()
+            );
+            sendDeliveryFailure(senderSession, message);
             return;
         }
 
         String payload = objectMapper.writeValueAsString(message);
         receiverSession.sendMessage(new TextMessage(payload));
+    }
+
+    private void sendDeliveryFailure(WebSocketSession senderSession, SignalingMessage original)
+            throws IOException {
+        if (!senderSession.isOpen()) {
+            log.warn(
+                    "Cannot report signaling delivery failure because sender session is closed. "
+                            + "type={}, roomId={}, from={}, to={}, sessionId={}",
+                    original.getType(),
+                    original.getRoomId(),
+                    original.getFrom(),
+                    original.getTo(),
+                    senderSession.getId()
+            );
+            return;
+        }
+
+        boolean callInvite = "CALL_INVITE".equals(original.getType());
+        Map<String, Object> data = new LinkedHashMap<>();
+        Object callId = extractCallId(original.getData());
+        if (callId != null) {
+            data.put("callId", callId);
+        }
+        data.put("reason", callInvite ? "AI_SERVER_UNAVAILABLE" : "RECEIVER_UNAVAILABLE");
+        data.put(
+                "detail",
+                callInvite
+                        ? "AI 통화 서버에 연결할 수 없습니다."
+                        : "시그널링 수신자에게 메시지를 전달할 수 없습니다."
+        );
+
+        SignalingMessage failure = new SignalingMessage(
+                callInvite ? "CALL_REJECT" : "SIGNALING_ERROR",
+                original.getRoomId(),
+                "server",
+                original.getFrom(),
+                data
+        );
+        senderSession.sendMessage(new TextMessage(objectMapper.writeValueAsString(failure)));
+    }
+
+    private Object extractCallId(Object data) {
+        if (data instanceof Map<?, ?> dataMap) {
+            return dataMap.get("callId");
+        }
+        return null;
     }
 
     private WebSocketSession getReceiverSession(String signalId) {
@@ -82,12 +143,17 @@ public class SignalingHandler extends TextWebSocketHandler {
     private void handleLeave(SignalingMessage message) {
         sessionRegistry.remove(message.getFrom());
 
-        System.out.println("Left signaling: " + message.getFrom());
+        log.info("Signaling participant left. signalId={}", message.getFrom());
     }
 
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         sessionRegistry.remove(session);
-        System.out.println("WebSocket closed: " + session.getId());
+        log.info(
+                "Signaling WebSocket closed. sessionId={}, statusCode={}, reason={}",
+                session.getId(),
+                status.getCode(),
+                status.getReason()
+        );
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/HomeController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/HomeController.java
@@ -78,7 +78,7 @@ public class HomeController {
         );
     }
 
-    @Operation(summary = "추천 리스트 조회 api", description = "추천 받은 유저 리스트를 조회합니다.")
+    @Operation(summary = "추천 리스트 조회 api", description = "추천 유저의 이름, 나이, 직업 인증자료 제출 여부, 거주지, 자기소개, MBTI, 해시태그를 조회합니다.")
     @GetMapping("/recommend")
     public ApiResponse<RecommendResDTO.RecommendationSliceDTO> recommend(
             @AuthenticationPrincipal CustomUserDetails currentUser,
@@ -99,7 +99,7 @@ public class HomeController {
 
     // TODO Big Five(개방성, 성실성, 외향성, 우호성, 신경증) 데이터 모델이 확정되면 성격 궁합 지표를 응답에 추가합니다.
     // TODO 사용자 쌍 기준 AI 궁합 분석 생성 및 저장 정책이 확정되면 분석 문구를 응답에 추가합니다.
-    @Operation(summary = "추천 유저 상세 조회", description = "추천 유저의 프로필과 Twin 정보, MBTI, 성격 해시태그를 조회합니다.")
+    @Operation(summary = "추천 유저 상세 조회", description = "추천 유저의 프로필, 직업, 직업 인증자료 제출 여부, Twin 정보, MBTI 지표, 성격 해시태그를 조회합니다.")
     @GetMapping("/recommendations/{target-user-uuid}")
     public ApiResponse<HomeResDTO.RecommendationDetailDTO> getRecommendationDetail(
             @AuthenticationPrincipal CustomUserDetails currentUser,

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/OnboardingController.java
@@ -7,6 +7,7 @@ import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewAnswerResDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.interview.InterviewQuestionResDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.onboarding.OnboardingReqDTO;
+import com.mirrorsoul.mirrorsoul_api.dto.onboarding.OnboardingResDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.visual.VisualReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.visual.VisualResDTO;
 import com.mirrorsoul.mirrorsoul_api.service.InterviewService;
@@ -61,11 +62,15 @@ public class OnboardingController {
 
     @Operation(summary = "닉네임 중복 확인", description = "닉네임 사용 가능 여부를 확인합니다.")
     @PostMapping("/profile/check-dup-nickname")
-    public ApiResponse<Void> checkDupNickname(@RequestBody OnboardingReqDTO.checkDupNicknameReqDTO req) {
-        if (onboardingService.checkDupNickname(req)) {
-            return ApiResponse.onSuccess("사용 가능한 닉네임입니다.");
-        }
-        return ApiResponse.onSuccess("사용 불가능한 중복 닉네임입니다.");
+    public ApiResponse<OnboardingResDTO.checkDupNicknameResDTO> checkDupNickname(
+            @Valid @RequestBody OnboardingReqDTO.checkDupNicknameReqDTO req) {
+        boolean available = onboardingService.checkDupNickname(req);
+        OnboardingResDTO.checkDupNicknameResDTO result =
+                OnboardingResDTO.checkDupNicknameResDTO.builder()
+                        .available(available)
+                        .build();
+
+        return ApiResponse.onSuccess("닉네임 중복 확인을 완료했습니다.", result);
     }
 
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/ProfileController.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/controller/ProfileController.java
@@ -124,7 +124,7 @@ public class ProfileController {
         return ApiResponse.onSuccess("닉네임 수정에 성공했습니다.");
     }
 
-    @Operation(summary = "회원 탈퇴 api", description = "계정을 비활성화(Soft Delete)합니다. 30일 뒤에 계정은 영구 삭제됩니다.")
+    @Operation(summary = "회원 탈퇴 api", description = "계정을 비활성화합니다. 30일 이내에 다시 로그인하면 복구되며, 30일 후에는 개인정보가 익명화됩니다.")
     @DeleteMapping
     public ApiResponse<Void> inActiveAccount (
             @AuthenticationPrincipal CustomUserDetails currentUser

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/User.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/User.java
@@ -107,6 +107,12 @@ public class User extends BaseTimeEntity {
     @Column(name = "refresh_token", length = 500)
     private String refreshToken;
 
+    @Column(name = "withdrawn_at")
+    private LocalDateTime withdrawnAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Enumerated(EnumType.STRING)
     @Setter
     @Column(nullable = false, length = 20)
@@ -118,6 +124,42 @@ public class User extends BaseTimeEntity {
 
     public void clearRefreshToken() {
         this.refreshToken = null;
+    }
+
+    public void deactivate(LocalDateTime withdrawnAt) {
+        this.status = UserStatus.INACTIVE;
+        this.withdrawnAt = withdrawnAt;
+        clearRefreshToken();
+    }
+
+    public boolean canRecover(LocalDateTime now) {
+        return status == UserStatus.INACTIVE
+                && withdrawnAt != null
+                && now.isBefore(withdrawnAt.plusDays(30));
+    }
+
+    public void reactivate() {
+        this.status = UserStatus.ACTIVE;
+        this.withdrawnAt = null;
+    }
+
+    public void anonymize(LocalDateTime deletedAt) {
+        this.email = "deleted-" + uuid + "@deleted.invalid";
+        this.passwordHash = "DELETED:" + UUID.randomUUID();
+        this.name = "탈퇴한 사용자";
+        this.gender = null;
+        this.job = null;
+        this.jobDescription = null;
+        this.jobCertificationObjectKey = null;
+        this.selfIntroduction = null;
+        this.birthDate = null;
+        this.residenceRegion = null;
+        this.profileImageUrl = null;
+        this.lastActiveAt = null;
+        this.refreshToken = null;
+        this.matchingEnabled = false;
+        this.status = UserStatus.DELETED;
+        this.deletedAt = deletedAt;
     }
 
     public void updatePassword(String passwordHash) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/enums/UserStatus.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/enums/UserStatus.java
@@ -6,6 +6,7 @@ public enum UserStatus {
     ONBOARD_C, // 성격 유형 완료
     ONBOARD_D, // 음성 인터뷰 완료
     ACTIVE, // 얼굴 스캔 완료 (온보딩 전체 완료)
-    INACTIVE, // 비활성화, 삭제 계정
+    INACTIVE, // 탈퇴 후 30일 이내, 복구 가능
+    DELETED, // 30일 경과 후 개인정보 익명화 완료
 
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/RecommendResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/RecommendResDTO.java
@@ -1,5 +1,7 @@
 package com.mirrorsoul.mirrorsoul_api.dto;
 
+import com.mirrorsoul.mirrorsoul_api.domain.enums.Job;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.MbtiType;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,8 +21,21 @@ public final class RecommendResDTO {
     public record RecommendationDTO(
             UUID userUuid,
             String name,
+            Integer age,
+            Job job,
+            boolean jobCertificationSubmitted,
+            ResidenceDTO residence,
+            String selfIntroduction,
+            MbtiType mbti,
+            List<String> hashtags,
             String profileImageUrl,
             int recommendationScore
+    ) {
+    }
+
+    public record ResidenceDTO(
+            String sidoName,
+            String sigunguName
     ) {
     }
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/home/HomeResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/home/HomeResDTO.java
@@ -1,6 +1,7 @@
 package com.mirrorsoul.mirrorsoul_api.dto.home;
 
 import com.mirrorsoul.mirrorsoul_api.domain.enums.MbtiType;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.Job;
 import java.util.List;
 import java.util.UUID;
 
@@ -64,8 +65,11 @@ public final class HomeResDTO {
             String profileImageUrl,
             Integer syncRate,
             RegionDTO region,
+            Job job,
+            boolean jobCertificationSubmitted,
             String selfIntroduction,
             MbtiType mbti,
+            MbtiIndicatorsDTO mbtiIndicators,
             List<String> hashtags,
             VoicePreviewDTO voicePreview
     ) {
@@ -74,6 +78,14 @@ public final class HomeResDTO {
     public record RegionDTO(
             String sidoName,
             String sigunguName
+    ) {
+    }
+
+    public record MbtiIndicatorsDTO(
+            Integer ieScore,
+            Integer nsScore,
+            Integer ftScore,
+            Integer pjScore
     ) {
     }
 

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/MbtiProfileRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/MbtiProfileRepository.java
@@ -1,10 +1,14 @@
 package com.mirrorsoul.mirrorsoul_api.repository;
 
 import com.mirrorsoul.mirrorsoul_api.domain.MbtiProfile;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MbtiProfileRepository extends JpaRepository<MbtiProfile, Long> {
 
     Optional<MbtiProfile> findByUser_Id(Long userId);
+
+    List<MbtiProfile> findAllByUser_IdIn(Collection<Long> userIds);
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/PushDeviceRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/PushDeviceRepository.java
@@ -16,4 +16,6 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     Optional<PushDevice> findByInstallationIdAndUserUuid(UUID installationId, UUID userUuid);
 
     List<PushDevice> findAllByUserUuidInAndEnabledTrue(Collection<UUID> userUuids);
+
+    void deleteAllByUserUuidIn(Collection<UUID> userUuids);
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/UserRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.mirrorsoul.mirrorsoul_api.repository;
 
 import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.Gender;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,6 +19,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select user from User user where user.email = :email")
+    Optional<User> findByEmailForUpdate(@Param("email") String email);
+
     Optional<User> findByUuid(UUID uuid);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -27,6 +32,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByName(String name);
 
     boolean existsByEmail(String email);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<User> findAllByStatusAndWithdrawnAtLessThanEqual(
+            UserStatus status,
+            LocalDateTime withdrawnAt
+    );
 
     @Query("""
         select candidate

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/scheduler/WithdrawnAccountCleanupScheduler.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/scheduler/WithdrawnAccountCleanupScheduler.java
@@ -1,0 +1,24 @@
+package com.mirrorsoul.mirrorsoul_api.scheduler;
+
+import com.mirrorsoul.mirrorsoul_api.service.WithdrawnAccountCleanupService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawnAccountCleanupScheduler {
+
+    private final WithdrawnAccountCleanupService cleanupService;
+
+    @Scheduled(cron = "${account.cleanup.cron:0 0 3 * * *}", zone = "${account.cleanup.zone:Asia/Seoul}")
+    public void anonymizeExpiredAccounts() {
+        int count = cleanupService.anonymizeExpiredAccounts(LocalDateTime.now());
+        if (count > 0) {
+            log.info("Anonymized expired withdrawn accounts. count={}", count);
+        }
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/AuthService.java
@@ -12,6 +12,7 @@ import com.mirrorsoul.mirrorsoul_api.dto.login.RefreshTokenResDTO;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,15 +30,20 @@ public class AuthService {
 
     @Transactional
     public LoginResDTO login(LoginReqDTO request) {
-        User user = userRepository.findByEmail(request.email())
+        User user = userRepository.findByEmailForUpdate(request.email())
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.INVALID_LOGIN, "Invalid email or password."));
-
-        if (UserStatus.INACTIVE.equals(user.getStatus())) {
-            throw new GeneralException(GeneralErrorCode.FORBIDDEN, "Inactive user.");
-        }
 
         if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
             throw new GeneralException(GeneralErrorCode.INVALID_LOGIN, "Invalid email or password.");
+        }
+
+        if (UserStatus.INACTIVE.equals(user.getStatus())) {
+            if (!user.canRecover(LocalDateTime.now())) {
+                throw new GeneralException(GeneralErrorCode.FORBIDDEN, "Account recovery period has expired.");
+            }
+            user.reactivate();
+        } else if (UserStatus.DELETED.equals(user.getStatus())) {
+            throw new GeneralException(GeneralErrorCode.FORBIDDEN, "Deleted user.");
         }
 
         String accessToken = tokenProvider.createAccessToken(user);
@@ -61,7 +67,7 @@ public class AuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.INVALID_TOKEN, "User for token not found."));
 
-        if (UserStatus.INACTIVE.equals(user.getStatus())) {
+        if (UserStatus.INACTIVE.equals(user.getStatus()) || UserStatus.DELETED.equals(user.getStatus())) {
             throw new GeneralException(GeneralErrorCode.FORBIDDEN, "Inactive user.");
         }
 

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/OnboardingService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/OnboardingService.java
@@ -39,7 +39,7 @@ public class OnboardingService {
             throw new GeneralException(FORBIDDEN, "ONBOARD_A 상태의 사용자만 페르소나를 저장할 수 있습니다.");
         }
 
-        user.setName(req.getNickname());
+        user.setName(req.getNickname().trim());
 
         Region region = regionRepository.findBySidoNameAndSigunguNameAndEupmyeondongName(
                 req.getSidoName(),
@@ -62,12 +62,7 @@ public class OnboardingService {
     @Transactional(readOnly = true)
     public Boolean checkDupNickname(OnboardingReqDTO.checkDupNicknameReqDTO req) {
 
-        String nickname = req.getNickname();
-
-        if (nickname == null || nickname.trim().isEmpty()) {
-            return false;
-        }
-        return !userRepository.existsByName(nickname);
+        return !userRepository.existsByName(req.getNickname().trim());
     }
 
     public void putPersonality(OnboardingReqDTO.personalityReqDTO req, UUID userUuid) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/ProfileService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/ProfileService.java
@@ -7,6 +7,7 @@ import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileReqDTO;
 import com.mirrorsoul.mirrorsoul_api.dto.profile.ProfileResDTO;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -107,8 +108,7 @@ public class ProfileService {
     @Transactional
     public void inactiveAccount(UUID userUuid) {
         User user = getUser(userUuid);
-        user.setStatus(UserStatus.INACTIVE);
-        user.clearRefreshToken();
+        user.deactivate(LocalDateTime.now());
     }
 
     private User getUser(UUID userUuid) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendService.java
@@ -6,14 +6,20 @@ import com.mirrorsoul.mirrorsoul_api.domain.Region;
 import com.mirrorsoul.mirrorsoul_api.domain.Sigungu;
 import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.UserPreferredSigungu;
+import com.mirrorsoul.mirrorsoul_api.domain.ClonePersonalityTag;
+import com.mirrorsoul.mirrorsoul_api.domain.MbtiProfile;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.MbtiType;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.dto.RecommendResDTO;
 import com.mirrorsoul.mirrorsoul_api.recommendation.UserEmbeddingRepository;
 import com.mirrorsoul.mirrorsoul_api.recommendation.VectorSimilarityScores;
 import com.mirrorsoul.mirrorsoul_api.repository.UserPreferredSigunguRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.ClonePersonalityTagRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.MbtiProfileRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +44,8 @@ public class RecommendService {
     private final UserPreferredSigunguRepository preferredSigunguRepository;
     private final RecommendationScoreCalculator scoreCalculator;
     private final ObjectProvider<UserEmbeddingRepository> embeddingRepositoryProvider;
+    private final MbtiProfileRepository mbtiProfileRepository;
+    private final ClonePersonalityTagRepository clonePersonalityTagRepository;
 
     public RecommendResDTO.RecommendationSliceDTO getRecommendations(
             UUID currentUserUuid,
@@ -74,6 +82,8 @@ public class RecommendService {
                 requester.getUuid(),
                 candidates
         );
+        Map<Long, MbtiType> mbtiByUserId = loadMbtiByUserId(candidates);
+        Map<Long, List<String>> hashtagsByUserId = loadHashtagsByUserId(candidates);
 
         Region requesterResidence = requester.getResidenceRegion();
         List<Sigungu> requesterPreferredSigungu = loadPreferredSigungu(requester);
@@ -91,6 +101,13 @@ public class RecommendService {
                     return new RecommendResDTO.RecommendationDTO(
                             candidate.getUuid(),
                             candidate.getName(),
+                            calculateAge(candidate.getBirthDate(), today),
+                            candidate.getJob(),
+                            hasSubmittedJobCertification(candidate),
+                            toResidence(candidate.getResidenceRegion()),
+                            candidate.getSelfIntroduction(),
+                            mbtiByUserId.get(candidate.getId()),
+                            hashtagsByUserId.getOrDefault(candidate.getId(), List.of()),
                             candidate.getProfileImageUrl(),
                             score
                     );
@@ -138,6 +155,48 @@ public class RecommendService {
                         VectorSimilarityScores::userUuid,
                         Function.identity()
                 ));
+    }
+
+    private Map<Long, MbtiType> loadMbtiByUserId(List<User> candidates) {
+        if (candidates.isEmpty()) {
+            return Map.of();
+        }
+        return mbtiProfileRepository.findAllByUser_IdIn(userIds(candidates)).stream()
+                .collect(Collectors.toMap(
+                        profile -> profile.getUser().getId(),
+                        MbtiProfile::getMbti
+                ));
+    }
+
+    private Map<Long, List<String>> loadHashtagsByUserId(List<User> candidates) {
+        if (candidates.isEmpty()) {
+            return Map.of();
+        }
+        return clonePersonalityTagRepository.findAllByUserIds(userIds(candidates)).stream()
+                .collect(Collectors.groupingBy(
+                        tag -> tag.getClone().getUser().getId(),
+                        Collectors.mapping(ClonePersonalityTag::getContent, Collectors.toList())
+                ));
+    }
+
+    private List<Long> userIds(List<User> candidates) {
+        return candidates.stream().map(User::getId).toList();
+    }
+
+    private Integer calculateAge(LocalDate birthDate, LocalDate today) {
+        return birthDate == null ? null : Period.between(birthDate, today).getYears();
+    }
+
+    private boolean hasSubmittedJobCertification(User user) {
+        return user.getJobCertificationObjectKey() != null
+                && !user.getJobCertificationObjectKey().isBlank();
+    }
+
+    private RecommendResDTO.ResidenceDTO toResidence(Region region) {
+        if (region == null) {
+            return null;
+        }
+        return new RecommendResDTO.ResidenceDTO(region.getSidoName(), region.getSigunguName());
     }
 
 }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailService.java
@@ -5,6 +5,7 @@ import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralExceptio
 import com.mirrorsoul.mirrorsoul_api.domain.AiVoiceProfile;
 import com.mirrorsoul.mirrorsoul_api.domain.Clone;
 import com.mirrorsoul.mirrorsoul_api.domain.ClonePersonalityTag;
+import com.mirrorsoul.mirrorsoul_api.domain.MbtiProfile;
 import com.mirrorsoul.mirrorsoul_api.domain.Region;
 import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
@@ -48,6 +49,8 @@ public class RecommendationDetailService {
         }
         Clone clone = cloneRepository.findByUserUuid(targetUserUuid)
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.CLONE_NOT_FOUND));
+        MbtiProfile mbtiProfile = mbtiProfileRepository.findByUser_Id(target.getId())
+                .orElse(null);
 
         return new HomeResDTO.RecommendationDetailDTO(
                 target.getUuid(),
@@ -56,10 +59,11 @@ public class RecommendationDetailService {
                 target.getProfileImageUrl(),
                 clone.getSyncRate(),
                 toRegion(target.getResidenceRegion()),
+                target.getJob(),
+                hasSubmittedJobCertification(target),
                 target.getSelfIntroduction(),
-                mbtiProfileRepository.findByUser_Id(target.getId())
-                        .map(profile -> profile.getMbti())
-                        .orElse(null),
+                mbtiProfile == null ? null : mbtiProfile.getMbti(),
+                toMbtiIndicators(mbtiProfile),
                 clonePersonalityTagRepository
                         .findAllByCloneIdOrderByDisplayOrderAsc(clone.getId()).stream()
                         .map(ClonePersonalityTag::getContent)
@@ -93,6 +97,23 @@ public class RecommendationDetailService {
             return null;
         }
         return new HomeResDTO.RegionDTO(region.getSidoName(), region.getSigunguName());
+    }
+
+    private boolean hasSubmittedJobCertification(User user) {
+        return user.getJobCertificationObjectKey() != null
+                && !user.getJobCertificationObjectKey().isBlank();
+    }
+
+    private HomeResDTO.MbtiIndicatorsDTO toMbtiIndicators(MbtiProfile profile) {
+        if (profile == null) {
+            return null;
+        }
+        return new HomeResDTO.MbtiIndicatorsDTO(
+                profile.getIeScore(),
+                profile.getNsScore(),
+                profile.getFtScore(),
+                profile.getPjScore()
+        );
     }
 
     private Integer calculateAge(LocalDate birthDate) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/WithdrawnAccountCleanupService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/WithdrawnAccountCleanupService.java
@@ -1,0 +1,38 @@
+package com.mirrorsoul.mirrorsoul_api.service;
+
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
+import com.mirrorsoul.mirrorsoul_api.repository.PushDeviceRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawnAccountCleanupService {
+
+    private static final long RECOVERY_PERIOD_DAYS = 30;
+
+    private final UserRepository userRepository;
+    private final PushDeviceRepository pushDeviceRepository;
+
+    @Transactional
+    public int anonymizeExpiredAccounts(LocalDateTime now) {
+        LocalDateTime cutoff = now.minusDays(RECOVERY_PERIOD_DAYS);
+        List<User> expiredUsers = userRepository
+                .findAllByStatusAndWithdrawnAtLessThanEqual(UserStatus.INACTIVE, cutoff);
+
+        if (expiredUsers.isEmpty()) {
+            return 0;
+        }
+
+        List<UUID> userUuids = expiredUsers.stream().map(User::getUuid).toList();
+        pushDeviceRepository.deleteAllByUserUuidIn(userUuids);
+        expiredUsers.forEach(user -> user.anonymize(now));
+        return expiredUsers.size();
+    }
+}

--- a/src/main/resources/db/migration/V30__add_user_withdrawal_lifecycle.sql
+++ b/src/main/resources/db/migration/V30__add_user_withdrawal_lifecycle.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+    ADD COLUMN withdrawn_at DATETIME NULL,
+    ADD COLUMN deleted_at DATETIME NULL;
+
+UPDATE users
+SET withdrawn_at = COALESCE(updated_at, CURRENT_TIMESTAMP)
+WHERE status = 'INACTIVE'
+  AND withdrawn_at IS NULL;
+
+CREATE INDEX idx_users_status_withdrawn_at
+    ON users (status, withdrawn_at);

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/common/webRTC/SignalingHandlerTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/common/webRTC/SignalingHandlerTest.java
@@ -1,0 +1,48 @@
+package com.mirrorsoul.mirrorsoul_api.common.webRTC;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import tools.jackson.databind.ObjectMapper;
+
+class SignalingHandlerTest {
+
+    @Test
+    void unavailableAiServerReturnsCallRejectToSender() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        SignalingHandler handler = new SignalingHandler(
+                objectMapper,
+                new WebSocketSessionRegistry()
+        );
+        WebSocketSession sender = mock(WebSocketSession.class);
+        when(sender.isOpen()).thenReturn(true);
+        when(sender.getId()).thenReturn("sender-session");
+
+        handler.handleMessage(sender, new TextMessage("""
+                {
+                  "type": "CALL_INVITE",
+                  "roomId": "room-1",
+                  "from": "signal:user:caller",
+                  "to": "signal:user:ai",
+                  "data": {"callId": 42}
+                }
+                """));
+
+        ArgumentCaptor<TextMessage> responseCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(sender).sendMessage(responseCaptor.capture());
+        Map<?, ?> response = objectMapper.readValue(responseCaptor.getValue().getPayload(), Map.class);
+        Map<?, ?> data = (Map<?, ?>) response.get("data");
+
+        assertThat(response.get("type")).isEqualTo("CALL_REJECT");
+        assertThat(response.get("to")).isEqualTo("signal:user:caller");
+        assertThat(data.get("callId")).isEqualTo(42);
+        assertThat(data.get("reason")).isEqualTo("AI_SERVER_UNAVAILABLE");
+    }
+}

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/service/AccountWithdrawalLifecycleTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/service/AccountWithdrawalLifecycleTest.java
@@ -1,0 +1,96 @@
+package com.mirrorsoul.mirrorsoul_api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
+import com.mirrorsoul.mirrorsoul_api.common.jwt.TokenProvider;
+import com.mirrorsoul.mirrorsoul_api.domain.User;
+import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
+import com.mirrorsoul.mirrorsoul_api.dto.login.LoginReqDTO;
+import com.mirrorsoul.mirrorsoul_api.dto.login.LoginResDTO;
+import com.mirrorsoul.mirrorsoul_api.repository.PushDeviceRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AccountWithdrawalLifecycleTest {
+
+    @Test
+    void loginWithinThirtyDaysReactivatesWithdrawnAccount() {
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        TokenProvider tokenProvider = mock(TokenProvider.class);
+        AuthService service = new AuthService(userRepository, passwordEncoder, tokenProvider);
+        User user = activeUser();
+        user.deactivate(LocalDateTime.now().minusDays(29));
+
+        when(userRepository.findByEmailForUpdate("user@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+        when(tokenProvider.createAccessToken(user)).thenReturn("access-token");
+        when(tokenProvider.createRefreshToken(user)).thenReturn("refresh-token");
+
+        LoginResDTO response = service.login(new LoginReqDTO("user@example.com", "password"));
+
+        assertThat(response.userStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getWithdrawnAt()).isNull();
+        assertThat(user.getRefreshToken()).isEqualTo("refresh-token");
+    }
+
+    @Test
+    void loginAfterThirtyDaysDoesNotReactivateAccount() {
+        UserRepository userRepository = mock(UserRepository.class);
+        PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+        TokenProvider tokenProvider = mock(TokenProvider.class);
+        AuthService service = new AuthService(userRepository, passwordEncoder, tokenProvider);
+        User user = activeUser();
+        user.deactivate(LocalDateTime.now().minusDays(30).minusMinutes(1));
+
+        when(userRepository.findByEmailForUpdate("user@example.com")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password", "encoded-password")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.login(new LoginReqDTO("user@example.com", "password")))
+                .isInstanceOf(GeneralException.class);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.INACTIVE);
+    }
+
+    @Test
+    void cleanupAnonymizesExpiredAccountAndDeletesPushDevices() {
+        UserRepository userRepository = mock(UserRepository.class);
+        PushDeviceRepository pushDeviceRepository = mock(PushDeviceRepository.class);
+        WithdrawnAccountCleanupService service =
+                new WithdrawnAccountCleanupService(userRepository, pushDeviceRepository);
+        User user = activeUser();
+        LocalDateTime now = LocalDateTime.of(2026, 8, 20, 3, 0);
+        user.deactivate(now.minusDays(30));
+
+        when(userRepository.findAllByStatusAndWithdrawnAtLessThanEqual(
+                UserStatus.INACTIVE, now.minusDays(30))).thenReturn(List.of(user));
+
+        assertThat(service.anonymizeExpiredAccounts(now)).isEqualTo(1);
+        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(user.getEmail()).startsWith("deleted-").endsWith("@deleted.invalid");
+        assertThat(user.getName()).isEqualTo("탈퇴한 사용자");
+        assertThat(user.getDeletedAt()).isEqualTo(now);
+        assertThat(user.getMatchingEnabled()).isFalse();
+        verify(pushDeviceRepository).deleteAllByUserUuidIn(List.of(user.getUuid()));
+    }
+
+    private User activeUser() {
+        return User.builder()
+                .uuid(UUID.randomUUID())
+                .email("user@example.com")
+                .passwordHash("encoded-password")
+                .name("사용자")
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+}


### PR DESCRIPTION

## 개요

8월 17일 회의에서 확인된 백엔드 이슈와 프론트 요구사항을 반영했습니다.

## 주요 변경사항

### 1. 탈퇴 계정 복구 및 익명화

- 탈퇴 시 `INACTIVE` 상태와 탈퇴 시각을 저장합니다.
- 탈퇴 후 30일 이내에 로그인하면 계정이 자동으로 복구됩니다.
- 별도의 복구 API 없이 기존 로그인 API를 사용합니다.
- 탈퇴 후 30일이 지나면 매일 오전 3시 배치에서 개인정보를 익명화합니다.
- 익명화 완료 후 계정 상태는 `DELETED`가 됩니다.
- 채팅·매칭 기록의 참조 유지를 위해 사용자 행과 UUID는 보존합니다.
- 푸시 디바이스 토큰도 익명화 과정에서 삭제합니다.

> S3 객체 자체는 삭제하지 않고 DB의 URL 및 object key 연결만 제거합니다.

### 2. 닉네임 중복확인 응답 개선

`POST /onboarding/profile/check-dup-nickname`

기존에는 중복 여부와 관계없이 `isSuccess`가 항상 `true`여서 메시지 문자열로 결과를 판단해야 했습니다.

이제 `result.available`로 사용 가능 여부를 구분합니다.

```json
{
  "isSuccess": true,
  "message": "닉네임 중복 확인을 완료했습니다.",
  "result": {
    "available": false
  }
}
```

- `available: true`: 사용 가능
- `available: false`: 중복으로 사용 불가

닉네임 중복확인과 실제 프로필 저장 시 앞뒤 공백도 제거합니다.

### 3. 추천 사용자 목록 응답 확장

`GET /home/recommend?page=0&size=20`

추천 사용자별로 다음 정보를 반환합니다.

- 이름
- 나이
- 직업
- 직업 인증자료 제출 여부
- 거주지
- 자기소개
- MBTI
- 성격 해시태그
- 프로필 이미지
- 추천 점수

```json
{
  "userUuid": "사용자 UUID",
  "name": "홍길동",
  "age": 24,
  "job": "STUDENT",
  "jobCertificationSubmitted": true,
  "residence": {
    "sidoName": "서울특별시",
    "sigunguName": "강남구"
  },
  "selfIntroduction": "안녕하세요.",
  "mbti": "INFJ",
  "hashtags": [
    "차분한",
    "공감 능력이 좋은"
  ],
  "profileImageUrl": "https://...",
  "recommendationScore": 83
}
```

### 4. 추천 사용자 상세조회 응답 확장

`GET /home/recommendations/{target-user-uuid}`

기존 상세조회 응답에 다음 항목을 추가했습니다.

- 직업
- 직업 인증자료 제출 여부
- MBTI 지표

```json
{
  "job": "STUDENT",
  "jobCertificationSubmitted": true,
  "mbti": "INFJ",
  "mbtiIndicators": {
    "ieScore": 65,
    "nsScore": 40,
    "ftScore": 72,
    "pjScore": 55
  }
}
```

MBTI 정보가 없는 사용자는 `mbti`와 `mbtiIndicators`가 `null`일 수 있습니다.

> 현재 관리자 승인 상태가 없으므로 `jobCertificationSubmitted`는 직업 인증 완료 여부가 아니라 인증자료 제출 여부를 의미합니다.

### 5. WebSocket 시그널링 실패 응답 개선

기존에는 AI 서버 등 시그널링 수신자가 연결되어 있지 않으면 메시지가 별도 응답 없이 버려졌습니다.

이제 AI 서버가 연결되지 않은 상태에서 `CALL_INVITE`를 받으면 발신자에게 즉시 `CALL_REJECT`를 반환합니다.

```json
{
  "type": "CALL_REJECT",
  "roomId": "room-1",
  "from": "server",
  "to": "signal:user:caller",
  "data": {
    "callId": 42,
    "reason": "AI_SERVER_UNAVAILABLE",
    "detail": "AI 통화 서버에 연결할 수 없습니다."
  }
}
```

`OFFER`, `ANSWER`, `ICE` 등 다른 시그널링 메시지 전달에 실패하면 `SIGNALING_ERROR`를 반환합니다.

```json
{
  "type": "SIGNALING_ERROR",
  "data": {
    "reason": "RECEIVER_UNAVAILABLE",
    "detail": "시그널링 수신자에게 메시지를 전달할 수 없습니다."
  }
}
```

기존 `System.out.println()`은 구조화된 로그로 변경했습니다.

## 프론트 확인사항

- [ ] 닉네임 중복확인 시 `result.available` 사용
- [ ] 추천 목록 신규 필드 UI 연결
- [ ] 추천 상세의 `job` 연결
- [ ] `jobCertificationSubmitted` 연결
- [ ] `mbtiIndicators` 연결
- [ ] nullable 필드의 빈 상태 처리
- [ ] `CALL_REJECT / AI_SERVER_UNAVAILABLE` 수신 시 타이머를 기다리지 않고 즉시 실패 처리
- [ ] `SIGNALING_ERROR / RECEIVER_UNAVAILABLE` 처리
- [ ] 탈퇴 계정 로그인 성공 시 일반 로그인과 동일하게 화면 이동

## 이번 작업에서 제외된 내용

- 마이페이지 알림 설정과 실제 푸시 연결
- 관리자 직업 인증 승인 상태
- 사용자 가치관 성향 상세조회
- LLM 기반 `이 사람의 이야기` 생성
- S3 개인정보 파일 실제 삭제
- AI 서버 PyMySQL 커넥션 풀 적용
- 다중 인스턴스 WebSocket 세션 분산 처리

## 테스트

- 계정 탈퇴·복구·익명화 단위 테스트 통과
- 추천 사용자 상세조회 서비스 테스트 통과
- WebSocket 시그널링 실패 응답 테스트 통과
- Java 및 테스트 소스 컴파일 성공
- `git diff --check` 통과

> 전체 테스트 중 기존 H2 테스트 환경과 `V9` MySQL 마이그레이션 문법의 호환 문제로 애플리케이션 컨텍스트 테스트 1개가 실패합니다. 이번 변경으로 발생한 실패는 아닙니다.