### PR TITLE
[Fix] 8월 24일 회의록 내용 반영 1차

### DIFF
--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/RecommendationExposure.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/domain/RecommendationExposure.java
@@ -1,0 +1,70 @@
+package com.mirrorsoul.mirrorsoul_api.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@Table(
+        name = "recommendation_exposures",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_recommendation_exposures_requester_target",
+                        columnNames = {"requester_user_id", "target_user_id"}
+                )
+        },
+        indexes = {
+                @Index(
+                        name = "idx_recommendation_exposures_requester_last_exposed",
+                        columnList = "requester_user_id,last_exposed_at"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class RecommendationExposure extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "requester_user_id",
+            nullable = false,
+            updatable = false,
+            foreignKey = @ForeignKey(name = "fk_recommendation_exposures_requester")
+    )
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "target_user_id",
+            nullable = false,
+            updatable = false,
+            foreignKey = @ForeignKey(name = "fk_recommendation_exposures_target")
+    )
+    private User target;
+
+    @Column(name = "last_exposed_at", nullable = false)
+    private LocalDateTime lastExposedAt;
+
+    public void markExposedAt(LocalDateTime exposedAt) {
+        this.lastExposedAt = exposedAt;
+    }
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/RecommendResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/RecommendResDTO.java
@@ -27,7 +27,7 @@ public final class RecommendResDTO {
             ResidenceDTO residence,
             String selfIntroduction,
             MbtiType mbti,
-            List<String> hashtags,
+            List<String> personalityTags,
             String profileImageUrl,
             int recommendationScore
     ) {

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/home/HomeResDTO.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/dto/home/HomeResDTO.java
@@ -69,8 +69,8 @@ public final class HomeResDTO {
             boolean jobCertificationSubmitted,
             String selfIntroduction,
             MbtiType mbti,
-            MbtiIndicatorsDTO mbtiIndicators,
-            List<String> hashtags,
+            MbtiAxisScoresDTO mbtiAxisScores,
+            List<String> personalityTags,
             VoicePreviewDTO voicePreview
     ) {
     }
@@ -81,7 +81,7 @@ public final class HomeResDTO {
     ) {
     }
 
-    public record MbtiIndicatorsDTO(
+    public record MbtiAxisScoresDTO(
             Integer ieScore,
             Integer nsScore,
             Integer ftScore,

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/recommendation/RecommendationPolicy.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/recommendation/RecommendationPolicy.java
@@ -3,6 +3,7 @@ package com.mirrorsoul.mirrorsoul_api.recommendation;
 public final class RecommendationPolicy {
 
     public static final int SWIPE_REEXPOSURE_DAYS = 14;
+    public static final int RECOMMENDATION_EXPOSURE_DAYS = 14;
 
     private RecommendationPolicy() {
     }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/RecommendationExposureRepository.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/repository/RecommendationExposureRepository.java
@@ -1,0 +1,22 @@
+package com.mirrorsoul.mirrorsoul_api.repository;
+
+import com.mirrorsoul.mirrorsoul_api.domain.RecommendationExposure;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendationExposureRepository
+        extends JpaRepository<RecommendationExposure, Long> {
+
+    List<RecommendationExposure> findAllByRequesterIdAndTargetIdIn(
+            Long requesterId,
+            Collection<Long> targetIds
+    );
+
+    boolean existsByRequesterIdAndTargetIdAndLastExposedAtGreaterThanEqual(
+            Long requesterId,
+            Long targetId,
+            LocalDateTime exposedSince
+    );
+}

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendService.java
@@ -8,6 +8,7 @@ import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.UserPreferredSigungu;
 import com.mirrorsoul.mirrorsoul_api.domain.ClonePersonalityTag;
 import com.mirrorsoul.mirrorsoul_api.domain.MbtiProfile;
+import com.mirrorsoul.mirrorsoul_api.domain.RecommendationExposure;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.MbtiType;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.dto.RecommendResDTO;
@@ -17,11 +18,13 @@ import com.mirrorsoul.mirrorsoul_api.repository.UserPreferredSigunguRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.ClonePersonalityTagRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.MbtiProfileRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.RecommendationExposureRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -46,7 +49,9 @@ public class RecommendService {
     private final ObjectProvider<UserEmbeddingRepository> embeddingRepositoryProvider;
     private final MbtiProfileRepository mbtiProfileRepository;
     private final ClonePersonalityTagRepository clonePersonalityTagRepository;
+    private final RecommendationExposureRepository recommendationExposureRepository;
 
+    @Transactional
     public RecommendResDTO.RecommendationSliceDTO getRecommendations(
             UUID currentUserUuid,
             Pageable pageable
@@ -83,7 +88,7 @@ public class RecommendService {
                 candidates
         );
         Map<Long, MbtiType> mbtiByUserId = loadMbtiByUserId(candidates);
-        Map<Long, List<String>> hashtagsByUserId = loadHashtagsByUserId(candidates);
+        Map<Long, List<String>> personalityTagsByUserId = loadPersonalityTagsByUserId(candidates);
 
         Region requesterResidence = requester.getResidenceRegion();
         List<Sigungu> requesterPreferredSigungu = loadPreferredSigungu(requester);
@@ -107,7 +112,7 @@ public class RecommendService {
                             toResidence(candidate.getResidenceRegion()),
                             candidate.getSelfIntroduction(),
                             mbtiByUserId.get(candidate.getId()),
-                            hashtagsByUserId.getOrDefault(candidate.getId(), List.of()),
+                            personalityTagsByUserId.getOrDefault(candidate.getId(), List.of()),
                             candidate.getProfileImageUrl(),
                             score
                     );
@@ -122,6 +127,7 @@ public class RecommendService {
         int toIndex = Math.min(fromIndex + pageable.getPageSize(), rankedCandidates.size());
         List<RecommendResDTO.RecommendationDTO> recommendations =
                 rankedCandidates.subList(fromIndex, toIndex);
+        recordExposures(requester, candidates, recommendations, now);
 
         return new RecommendResDTO.RecommendationSliceDTO(
                 recommendations,
@@ -129,6 +135,48 @@ public class RecommendService {
                 pageable.getPageSize(),
                 toIndex < rankedCandidates.size()
         );
+    }
+
+    private void recordExposures(
+            User requester,
+            List<User> candidates,
+            List<RecommendResDTO.RecommendationDTO> recommendations,
+            LocalDateTime exposedAt
+    ) {
+        if (recommendations.isEmpty()) {
+            return;
+        }
+
+        Set<UUID> exposedUuids = recommendations.stream()
+                .map(RecommendResDTO.RecommendationDTO::userUuid)
+                .collect(Collectors.toSet());
+        List<User> exposedTargets = candidates.stream()
+                .filter(candidate -> exposedUuids.contains(candidate.getUuid()))
+                .toList();
+        List<Long> targetIds = exposedTargets.stream().map(User::getId).toList();
+        Map<Long, RecommendationExposure> existingByTargetId =
+                recommendationExposureRepository
+                        .findAllByRequesterIdAndTargetIdIn(requester.getId(), targetIds).stream()
+                        .collect(Collectors.toMap(
+                                exposure -> exposure.getTarget().getId(),
+                                Function.identity()
+                        ));
+
+        List<RecommendationExposure> exposures = exposedTargets.stream()
+                .map(target -> {
+                    RecommendationExposure exposure = existingByTargetId.get(target.getId());
+                    if (exposure == null) {
+                        return RecommendationExposure.builder()
+                                .requester(requester)
+                                .target(target)
+                                .lastExposedAt(exposedAt)
+                                .build();
+                    }
+                    exposure.markExposedAt(exposedAt);
+                    return exposure;
+                })
+                .toList();
+        recommendationExposureRepository.saveAll(exposures);
     }
 
     private List<Sigungu> loadPreferredSigungu(User requester) {
@@ -168,7 +216,7 @@ public class RecommendService {
                 ));
     }
 
-    private Map<Long, List<String>> loadHashtagsByUserId(List<User> candidates) {
+    private Map<Long, List<String>> loadPersonalityTagsByUserId(List<User> candidates) {
         if (candidates.isEmpty()) {
             return Map.of();
         }

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailService.java
@@ -14,14 +14,18 @@ import com.mirrorsoul.mirrorsoul_api.repository.AiVoiceProfileRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.ClonePersonalityTagRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.CloneRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.MbtiProfileRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.RecommendationExposureRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserBlockRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.mirrorsoul.mirrorsoul_api.recommendation.RecommendationPolicy.RECOMMENDATION_EXPOSURE_DAYS;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +37,7 @@ public class RecommendationDetailService {
     private final CloneRepository cloneRepository;
     private final MbtiProfileRepository mbtiProfileRepository;
     private final ClonePersonalityTagRepository clonePersonalityTagRepository;
+    private final RecommendationExposureRepository recommendationExposureRepository;
     private final AiVoiceProfileRepository aiVoiceProfileRepository;
     private final FileService fileService;
 
@@ -45,6 +50,15 @@ public class RecommendationDetailService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.RECOMMENDATION_TARGET_NOT_FOUND));
         if (currentUser.getId().equals(target.getId())
                 || userBlockRepository.existsBetween(currentUser.getId(), target.getId())) {
+            throw new GeneralException(GeneralErrorCode.RECOMMENDATION_TARGET_NOT_FOUND);
+        }
+        boolean exposed = recommendationExposureRepository
+                .existsByRequesterIdAndTargetIdAndLastExposedAtGreaterThanEqual(
+                        currentUser.getId(),
+                        target.getId(),
+                        LocalDateTime.now().minusDays(RECOMMENDATION_EXPOSURE_DAYS)
+                );
+        if (!exposed) {
             throw new GeneralException(GeneralErrorCode.RECOMMENDATION_TARGET_NOT_FOUND);
         }
         Clone clone = cloneRepository.findByUserUuid(targetUserUuid)
@@ -63,7 +77,7 @@ public class RecommendationDetailService {
                 hasSubmittedJobCertification(target),
                 target.getSelfIntroduction(),
                 mbtiProfile == null ? null : mbtiProfile.getMbti(),
-                toMbtiIndicators(mbtiProfile),
+                toMbtiAxisScores(mbtiProfile),
                 clonePersonalityTagRepository
                         .findAllByCloneIdOrderByDisplayOrderAsc(clone.getId()).stream()
                         .map(ClonePersonalityTag::getContent)
@@ -104,11 +118,11 @@ public class RecommendationDetailService {
                 && !user.getJobCertificationObjectKey().isBlank();
     }
 
-    private HomeResDTO.MbtiIndicatorsDTO toMbtiIndicators(MbtiProfile profile) {
+    private HomeResDTO.MbtiAxisScoresDTO toMbtiAxisScores(MbtiProfile profile) {
         if (profile == null) {
             return null;
         }
-        return new HomeResDTO.MbtiIndicatorsDTO(
+        return new HomeResDTO.MbtiAxisScoresDTO(
                 profile.getIeScore(),
                 profile.getNsScore(),
                 profile.getFtScore(),

--- a/src/main/java/com/mirrorsoul/mirrorsoul_api/service/SwipeService.java
+++ b/src/main/java/com/mirrorsoul/mirrorsoul_api/service/SwipeService.java
@@ -7,6 +7,7 @@ import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.SwipeAction;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.repository.SwipeHistoryRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.RecommendationExposureRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserBlockRepository;
 import java.time.LocalDateTime;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static com.mirrorsoul.mirrorsoul_api.recommendation.RecommendationPolicy.SWIPE_REEXPOSURE_DAYS;
+import static com.mirrorsoul.mirrorsoul_api.recommendation.RecommendationPolicy.RECOMMENDATION_EXPOSURE_DAYS;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class SwipeService {
     private final UserRepository userRepository;
     private final SwipeHistoryRepository swipeHistoryRepository;
     private final UserBlockRepository userBlockRepository;
+    private final RecommendationExposureRepository recommendationExposureRepository;
 
     @Transactional
     public void swipe(UUID swiperUuid, UUID targetUuid) {
@@ -39,6 +42,15 @@ public class SwipeService {
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.SWIPE_TARGET_UNAVAILABLE));
 
         if (userBlockRepository.existsBetween(swiper.getId(), target.getId())) {
+            throw new GeneralException(GeneralErrorCode.SWIPE_TARGET_UNAVAILABLE);
+        }
+        boolean exposed = recommendationExposureRepository
+                .existsByRequesterIdAndTargetIdAndLastExposedAtGreaterThanEqual(
+                        swiper.getId(),
+                        target.getId(),
+                        LocalDateTime.now().minusDays(RECOMMENDATION_EXPOSURE_DAYS)
+                );
+        if (!exposed) {
             throw new GeneralException(GeneralErrorCode.SWIPE_TARGET_UNAVAILABLE);
         }
 

--- a/src/main/resources/db/migration/V31__add_recommendation_exposures.sql
+++ b/src/main/resources/db/migration/V31__add_recommendation_exposures.sql
@@ -1,0 +1,21 @@
+CREATE TABLE recommendation_exposures (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    requester_user_id BIGINT NOT NULL,
+    target_user_id BIGINT NOT NULL,
+    last_exposed_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    CONSTRAINT pk_recommendation_exposures PRIMARY KEY (id),
+    CONSTRAINT uk_recommendation_exposures_requester_target
+        UNIQUE (requester_user_id, target_user_id),
+    CONSTRAINT fk_recommendation_exposures_requester
+        FOREIGN KEY (requester_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_recommendation_exposures_target
+        FOREIGN KEY (target_user_id) REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT chk_recommendation_exposures_different_users
+        CHECK (requester_user_id <> target_user_id)
+);
+
+CREATE INDEX idx_recommendation_exposures_requester_last_exposed
+    ON recommendation_exposures (requester_user_id, last_exposed_at);

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailServiceTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/service/RecommendationDetailServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 
 import com.mirrorsoul.mirrorsoul_api.common.apiPayload.code.GeneralErrorCode;
 import com.mirrorsoul.mirrorsoul_api.common.apiPayload.exception.GeneralException;
@@ -20,9 +21,11 @@ import com.mirrorsoul.mirrorsoul_api.repository.AiVoiceProfileRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.CloneRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.ClonePersonalityTagRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.MbtiProfileRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.RecommendationExposureRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserBlockRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,6 +39,7 @@ class RecommendationDetailServiceTest {
     private UserBlockRepository userBlockRepository;
     private MbtiProfileRepository mbtiProfileRepository;
     private ClonePersonalityTagRepository clonePersonalityTagRepository;
+    private RecommendationExposureRepository recommendationExposureRepository;
     private AiVoiceProfileRepository aiVoiceProfileRepository;
     private FileService fileService;
     private RecommendationDetailService service;
@@ -47,6 +51,7 @@ class RecommendationDetailServiceTest {
         userBlockRepository = mock(UserBlockRepository.class);
         mbtiProfileRepository = mock(MbtiProfileRepository.class);
         clonePersonalityTagRepository = mock(ClonePersonalityTagRepository.class);
+        recommendationExposureRepository = mock(RecommendationExposureRepository.class);
         aiVoiceProfileRepository = mock(AiVoiceProfileRepository.class);
         fileService = mock(FileService.class);
         service = new RecommendationDetailService(
@@ -55,6 +60,7 @@ class RecommendationDetailServiceTest {
                 cloneRepository,
                 mbtiProfileRepository,
                 clonePersonalityTagRepository,
+                recommendationExposureRepository,
                 aiVoiceProfileRepository,
                 fileService
         );
@@ -85,6 +91,12 @@ class RecommendationDetailServiceTest {
         when(target.getProfileImageUrl()).thenReturn("https://example.com/profile.jpg");
         when(target.getResidenceRegion()).thenReturn(region);
         when(target.getSelfIntroduction()).thenReturn("책과 음악을 좋아합니다.");
+        when(recommendationExposureRepository
+                .existsByRequesterIdAndTargetIdAndLastExposedAtGreaterThanEqual(
+                        org.mockito.ArgumentMatchers.eq(99L),
+                        org.mockito.ArgumentMatchers.eq(1L),
+                        any(LocalDateTime.class)
+                )).thenReturn(true);
         when(region.getSidoName()).thenReturn("서울특별시");
         when(region.getSigunguName()).thenReturn("강남구");
 
@@ -117,7 +129,7 @@ class RecommendationDetailServiceTest {
         assertThat(result.region().sigunguName()).isEqualTo("강남구");
         assertThat(result.selfIntroduction()).isEqualTo("책과 음악을 좋아합니다.");
         assertThat(result.mbti()).isEqualTo(MbtiType.INFJ);
-        assertThat(result.hashtags()).containsExactly("사고가 깊은", "차분한 말투");
+        assertThat(result.personalityTags()).containsExactly("사고가 깊은", "차분한 말투");
         assertThat(result.voicePreview().audioUrl())
                 .isEqualTo("https://example.com/signed-voice.mp3");
         assertThat(result.voicePreview().durationMs()).isEqualTo(18_000);
@@ -132,6 +144,28 @@ class RecommendationDetailServiceTest {
         when(userRepository.findByUuid(currentUserUuid)).thenReturn(Optional.of(currentUser));
         when(userRepository.findByUuid(targetUuid)).thenReturn(Optional.of(target));
         when(target.getStatus()).thenReturn(UserStatus.INACTIVE);
+
+        assertThatThrownBy(() -> service.getDetail(currentUserUuid, targetUuid))
+                .isInstanceOfSatisfying(
+                        GeneralException.class,
+                        exception -> assertThat(exception.getCode())
+                                .isEqualTo(GeneralErrorCode.RECOMMENDATION_TARGET_NOT_FOUND)
+                );
+    }
+
+    @Test
+    void getDetailRejectsTargetThatWasNotExposed() {
+        UUID targetUuid = UUID.randomUUID();
+        UUID currentUserUuid = UUID.randomUUID();
+        User currentUser = mock(User.class);
+        User target = mock(User.class);
+
+        when(userRepository.findByUuid(currentUserUuid)).thenReturn(Optional.of(currentUser));
+        when(userRepository.findByUuid(targetUuid)).thenReturn(Optional.of(target));
+        when(currentUser.getId()).thenReturn(99L);
+        when(target.getId()).thenReturn(1L);
+        when(target.getStatus()).thenReturn(UserStatus.ACTIVE);
+        when(target.getMatchingEnabled()).thenReturn(true);
 
         assertThatThrownBy(() -> service.getDetail(currentUserUuid, targetUuid))
                 .isInstanceOfSatisfying(

--- a/src/test/java/com/mirrorsoul/mirrorsoul_api/service/SwipeServiceTest.java
+++ b/src/test/java/com/mirrorsoul/mirrorsoul_api/service/SwipeServiceTest.java
@@ -15,6 +15,7 @@ import com.mirrorsoul.mirrorsoul_api.domain.User;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.SwipeAction;
 import com.mirrorsoul.mirrorsoul_api.domain.enums.UserStatus;
 import com.mirrorsoul.mirrorsoul_api.repository.SwipeHistoryRepository;
+import com.mirrorsoul.mirrorsoul_api.repository.RecommendationExposureRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserRepository;
 import com.mirrorsoul.mirrorsoul_api.repository.UserBlockRepository;
 import java.time.LocalDateTime;
@@ -29,13 +30,19 @@ class SwipeServiceTest {
     private UserRepository userRepository;
     private SwipeHistoryRepository swipeHistoryRepository;
     private SwipeService swipeService;
+    private RecommendationExposureRepository recommendationExposureRepository;
 
     @BeforeEach
     void setUp() {
         userRepository = mock(UserRepository.class);
         swipeHistoryRepository = mock(SwipeHistoryRepository.class);
+        recommendationExposureRepository = mock(RecommendationExposureRepository.class);
         swipeService = new SwipeService(
-                userRepository, swipeHistoryRepository, mock(UserBlockRepository.class));
+                userRepository,
+                swipeHistoryRepository,
+                mock(UserBlockRepository.class),
+                recommendationExposureRepository
+        );
     }
 
     @Test
@@ -47,6 +54,7 @@ class SwipeServiceTest {
 
         when(userRepository.findByUuid(swiperUuid)).thenReturn(Optional.of(swiper));
         when(userRepository.findByUuid(targetUuid)).thenReturn(Optional.of(target));
+        allowExposure(1L, 2L);
         when(swipeHistoryRepository.existsBySwiperIdAndTargetIdAndCreatedAtGreaterThanEqual(
                 any(), any(), any(LocalDateTime.class)
         )).thenReturn(false);
@@ -69,6 +77,7 @@ class SwipeServiceTest {
 
         when(userRepository.findByUuid(swiperUuid)).thenReturn(Optional.of(swiper));
         when(userRepository.findByUuid(targetUuid)).thenReturn(Optional.of(target));
+        allowExposure(1L, 2L);
         when(swipeHistoryRepository.existsBySwiperIdAndTargetIdAndCreatedAtGreaterThanEqual(
                 any(), any(), any(LocalDateTime.class)
         )).thenReturn(true);
@@ -104,6 +113,32 @@ class SwipeServiceTest {
                 GeneralErrorCode.SWIPE_TARGET_UNAVAILABLE
         );
         verify(swipeHistoryRepository, never()).save(any(SwipeHistory.class));
+    }
+
+    @Test
+    void swipeRejectsTargetThatWasNotExposed() {
+        UUID swiperUuid = UUID.randomUUID();
+        UUID targetUuid = UUID.randomUUID();
+        User swiper = user(1L, UserStatus.ACTIVE, true);
+        User target = user(2L, UserStatus.ACTIVE, true);
+
+        when(userRepository.findByUuid(swiperUuid)).thenReturn(Optional.of(swiper));
+        when(userRepository.findByUuid(targetUuid)).thenReturn(Optional.of(target));
+
+        assertError(
+                () -> swipeService.swipe(swiperUuid, targetUuid),
+                GeneralErrorCode.SWIPE_TARGET_UNAVAILABLE
+        );
+        verify(swipeHistoryRepository, never()).save(any(SwipeHistory.class));
+    }
+
+    private void allowExposure(Long requesterId, Long targetId) {
+        when(recommendationExposureRepository
+                .existsByRequesterIdAndTargetIdAndLastExposedAtGreaterThanEqual(
+                        org.mockito.ArgumentMatchers.eq(requesterId),
+                        org.mockito.ArgumentMatchers.eq(targetId),
+                        any(LocalDateTime.class)
+                )).thenReturn(true);
     }
 
     private User user(Long id, UserStatus status, boolean matchingEnabled) {


### PR DESCRIPTION
## 작업 내용

### 추천 API 응답 필드명 정리

프론트엔드 응답 계약에 맞게 추천 목록 및 상세 응답 필드명을 변경했습니다.

- `hashtags` → `personalityTags`
- `mbtiIndicators` → `mbtiAxisScores`
- MBTI 축 점수는 다음 필드로 반환
  - `ieScore`
  - `nsScore`
  - `ftScore`
  - `pjScore`
- 추천 목록과 상세 응답에서 기존 `mbti` 필드 유지
- 성격 태그는 기존과 동일하게 `displayOrder` 순으로 반환

### 추천 노출 이력 추가

추천 목록 API 응답에 실제 포함된 사용자만 상세 조회 및 스와이프할 수 있도록 추천 노출 이력을 추가했습니다.

- `recommendation_exposures` 테이블 추가
- 요청자와 추천 대상 조합에 유니크 제약 적용
- 최초 노출 시 이력 생성
- 동일 사용자가 다시 추천되면 `last_exposed_at` 갱신
- 추천 노출 이력 유효기간을 14일로 설정
  - 기존 스와이프 재노출 정책과 동일한 기간 사용

### 추천 상세 조회 접근 제어 강화

`GET /home/recommendations/{target-user-uuid}` 호출 시 다음 조건을 확인합니다.

- 대상 사용자가 활성 상태인지 확인
- 대상 사용자가 매칭을 허용했는지 확인
- 자기 자신인지 확인
- 양방향 차단 관계인지 확인
- 최근 14일 이내 요청자의 추천 목록에 포함됐는지 확인

추천 노출 이력이 없는 대상은 기존 보안 규칙에 따라 다음 오류를 반환합니다.

```text
RECOMMENDATION_TARGET_NOT_FOUND
HTTP 404
```
존재하지 않는 사용자, 접근할 수 없는 사용자, 추천되지 않은 사용자를 외부에서 구분할 수 없도록 기존 404 정책을 유지했습니다.
### 스와이프 접근 제어 강화
`POST /home/recommendations/{target-user-uuid}/swipe`에서도 최근 추천 노출 이력을 검증하도록 변경했습니다.

추천되지 않은 대상에 대한 임의 스와이프 요청은 다음 오류를 반환합니다.
```text
SWIPE_TARGET_UNAVAILABLE
HTTP 404
```